### PR TITLE
Do not use shared_ptr for implementation, rename weak_ptr to observer_ptr

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 ## Introduction
 
-This is a small header-only library, providing a unique-ownership smart pointer that can be observed with weak pointers. It is a mixture of `std::unique_ptr` and `std::shared_ptr`: it borrows the unique-ownership semantic of `std::unique_ptr` (movable, non-copiable), but allows creating `std::weak_ptr` instances to monitor the lifetime of the pointed object.
+This is a small header-only library, providing a unique-ownership smart pointer `observable_unique_ptr` that can be observed with non-owning pointers `observer_ptr`. It is a mixture of `std::unique_ptr` and `std::shared_ptr`: it borrows the unique-ownership semantic of `std::unique_ptr` (movable, non-copiable), but allows creating observer pointers (like `std::weak_ptr` for `std::shared_ptr`) to monitor the lifetime of the pointed object.
 
-This is useful for cases where the shared-ownership of `std::shared_ptr` is not desirable, e.g., when lifetime must be carefully controlled and not be allowed to extend, yet non-owning "weak" references to the object may exist after the object has been deleted.
+This is useful for cases where the shared-ownership of `std::shared_ptr` is not desirable, e.g., when lifetime must be carefully controlled and not be allowed to extend, yet non-owning/weak/observer references to the object may exist after the object has been deleted.
 
-Note: Because of the unique ownership model, weak pointers locking cannot extend the lifetime of the pointed object, hence `observable_unique_ptr` provides less thread-safety compared to `std::shared_ptr`. This is also true of `std::unique_ptr`, and is a fundamental limitation of unique ownership. Do not use this library if the lifetime of your objects is not well understood.
+Note: Because of the unique ownership model, observer pointers cannot extend the lifetime of the pointed object, hence `observable_unique_ptr`/`observer_ptr` provides less thread-safety compared to `std::shared_ptr`/`std::weak_ptr`. This is also true of `std::unique_ptr`, and is a fundamental limitation of unique ownership. If this is an issue, you will need either to add your own explicit locking logic, or use `std::shared_ptr`/`std::weak_ptr`.
 
 
 ## Usage
 
-This is a header-only library. You have multiple ways to set it up:
+This is a header-only library requiring a C++17-compliant compiler. You have multiple ways to set it up:
  - just include this repository as a submodule in your own git repository and use CMake `add_subdirectory`,
  - use CMake `FetchContent`,
  - download the header and include it in your own sources.
@@ -28,35 +28,34 @@ From there, include the single header `<oup/observable_unique_ptr.hpp>`, and dir
 #include <cassert>
 
 int main() {
-    // Weak pointer that will outlive the object
-    oup::weak_ptr<std::string> wptr;
+    // Non-owning pointer that will outlive the object
+    oup::observer_ptr<std::string> obs_ptr;
 
     {
         // Unique pointer that owns the object
-        auto ptr = oup::make_observable_unique<std::string>("hello");
+        auto owner_ptr = oup::make_observable_unique<std::string>("hello");
 
-        // Make the weak pointer observe the object
-        wptr = ptr;
+        // Make the observer pointer point to the object
+        obs_ptr = owner_ptr;
 
-        // Weak pointer is valid
-        assert(!wptr.expired());
+        // Observer pointer is valid
+        assert(!obs_ptr.expired());
 
-        // It can be locked to get a (non-owning!) pointer to the object
-        std::string* s = wptr.lock();
-        assert(s != nullptr);
-        std::cout << *s << std::endl;
+        // It can be used like a regular raw pointer
+        assert(obs_ptr != nullptr);
+        std::cout << *obs_ptr << std::endl;
 
         // The unique pointer cannot be copied
-        auto tmp_copied = ptr; // error!
+        auto tmp_copied = owner_ptr; // error!
 
         // ... but it can be moved
-        auto tmp_moved = std::move(ptr); // OK
+        auto tmp_moved = std::move(owner_ptr); // OK
     }
 
     // The unique pointer has gone out of scope, the object is deleted,
-    // the weak pointer is now null.
-    assert(wptr.expired());
-    assert(wptr.lock() == nullptr);
+    // the observer pointer is now null.
+    assert(obs_ptr.expired());
+    assert(obs_ptr == nullptr);
 
     return 0;
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-This is a small header-only library, providing a unique-ownership smart pointer `observable_unique_ptr` that can be observed with non-owning pointers `observer_ptr`. It is a mixture of `std::unique_ptr` and `std::shared_ptr`: it borrows the unique-ownership semantic of `std::unique_ptr` (movable, non-copiable), but allows creating observer pointers (like `std::weak_ptr` for `std::shared_ptr`) to monitor the lifetime of the pointed object.
+This is a small header-only library, providing a unique-ownership smart pointer `observable_unique_ptr` that can be observed with non-owning pointers `observer_ptr`. It is a mixture of `std::unique_ptr` and `std::shared_ptr`: it borrows the unique-ownership semantic of `std::unique_ptr` (movable, non-copiable), but allows creating `observer_ptr` to monitor the lifetime of the pointed object (like `std::weak_ptr` for `std::shared_ptr`).
 
 This is useful for cases where the shared-ownership of `std::shared_ptr` is not desirable, e.g., when lifetime must be carefully controlled and not be allowed to extend, yet non-owning/weak/observer references to the object may exist after the object has been deleted.
 
@@ -64,16 +64,12 @@ int main() {
 
 ## Limitations
 
-The follownig limitations are imposed by the current implementation (reusing the parts from `std::shared_ptr` and `std::weak_ptr`), or features that were not implemented simply because of lack of motivation. A higher quality implementation of this API could get rid of most (if not all) of them.
+The follownig limitations are features that were not implemented simply because of lack of motivation.
 
  - `observable_unique_ptr` does not support pointers to arrays, but `std::unique_ptr` and `std::shared_ptr` both do.
  - `observable_unique_ptr` does not support custom allocators, but `std::shared_ptr` does.
- - `observable_unique_ptr` does not have a `release()` function to let go of the ownership, which `std::unique_ptr` has.
- - `observable_unique_ptr` allows moving from other `observable_unique_ptr` only if the deleter type is exactly the same, while `std::unique_ptr` allows moving from a convertible deleter.
- - Contrary to `std::unique_ptr`, which stores the deleter in-place next to the pointer to the owned object, an `observable_unique_ptr` follows the model from `std::shared_ptr` where the deleter is type-erased and stored on the heap. Therefore, an `observable_unique_ptr` may or may not own a deleter instance; if in doubt, check `has_deleter()` before calling `get_deleter()`, or use `try_get_deleter()`.
- - A moved-from `observable_unique_ptr` will not own a deleter instance.
 
 
 ## Notes
 
-An alternative implementation of an "observable unique pointer" can be found [here](https://www.codeproject.com/articles/1011134/smart-observers-to-use-with-unique-ptr). It does not compile out of the box with gcc unfortunately, but it does contain more features (like creating an observer pointer from a raw `this`) and a lower-overhead implementation (not based on `std::shared_ptr`/`std::weak_ptr`). Have a look to check if this better suits your needs.
+An alternative implementation of an "observable unique pointer" can be found [here](https://www.codeproject.com/articles/1011134/smart-observers-to-use-with-unique-ptr). It does not compile out of the box with gcc unfortunately, but it does contain more features (like creating an observer pointer from a raw `this`). Have a look to check if this better suits your needs.

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -39,14 +39,6 @@ struct control_block {
 *      less thread-safety compared to std::shared_ptr.
 *    - observable_unique_ptr does not support arrays.
 *    - observable_unique_ptr does not allow custom allocators.
-*    - observable_unique_ptr does not have a release() function to let go of
-*      the ownership.
-*    - observable_unique_ptr allows moving from other observable_unique_ptr
-*      only if the deleter type is exactly the same, while std::unique_ptr
-*      allows moving from a convertible deleter.
-*    - observable_unique_ptr may not own a deleter instance; if in doubt, check
-*      has_deleter() before calling get_deleter(), or use try_get_deleter().
-*    - a moved-from observable_unique_ptr will not own a deleter instance.
 */
 template<typename T, typename Deleter = std::default_delete<T>>
 class observable_unique_ptr {

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -273,7 +273,7 @@ bool operator!= (std::nullptr_t, const observable_unique_ptr<T,Deleter>& value) 
 
 template<typename T, typename U, typename Deleter>
 bool operator== (const observable_unique_ptr<T,Deleter>& first,
-    const observable_unique_ptr<U,Deleter> second) noexcept {
+    const observable_unique_ptr<U,Deleter>& second) noexcept {
     return first.get() == second.get();
 }
 

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -382,6 +382,13 @@ public:
         return std::weak_ptr<T>::lock().get();
     }
 
+    /// Check if this pointer points to a valid object.
+    /** \return 'true' if the pointed object is valid, 'false' otherwise
+    */
+    explicit operator bool() noexcept {
+        return !expired();
+    }
+
     /// Swap the content of this pointer with that of another pointer.
     /** \param other The other pointer to swap with
     */

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -363,6 +363,25 @@ public:
         return std::weak_ptr<T>::lock().get();
     }
 
+    /// Get a reference to the pointed object (undefined behavior if deleted).
+    /** \return A reference to the pointed object
+    *   \note Using this function if expired() is 'true' will leave to undefined behavior.
+    */
+    T& operator*() const noexcept {
+        return *std::weak_ptr<T>::lock().get();
+    }
+
+    /// Get a non-owning raw pointer to the pointed object, or nullptr if deleted.
+    /** \return 'nullptr' if expired() is 'true', or the pointed object otherwise
+    *   \note Contrary to std::weak_ptr::lock(), this does not extend the lifetime
+    *         of the pointed object. Therefore, when calling this function, you must
+    *         make sure that the owning observable_unique_ptr will not be reset until
+    *         you are done using the raw pointer.
+    */
+    T* operator->() const noexcept {
+        return std::weak_ptr<T>::lock().get();
+    }
+
     /// Swap the content of this pointer with that of another pointer.
     /** \param other The other pointer to swap with
     */

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -185,6 +185,17 @@ public:
     *   \note After this observable_unique_ptr is created, the source
     *         pointer is set to null and looses ownership.
     */
+    observable_unique_ptr(observable_unique_ptr&& value) noexcept :
+        observable_unique_ptr(value.block, value.pointer, std::move(value.deleter)) {
+        value.block = nullptr;
+        value.pointer = nullptr;
+    }
+
+    /// Transfer ownership by implicit casting
+    /** \param value The pointer to take ownership from
+    *   \note After this observable_unique_ptr is created, the source
+    *         pointer is set to null and looses ownership.
+    */
     template<typename U, typename D/*, typename enable = std::enable_if_t<std::is_convertible_v<U*, T*>>*/>
     observable_unique_ptr(observable_unique_ptr<U,D>&& value) noexcept :
         observable_unique_ptr(value.block, value.pointer) {

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -359,7 +359,7 @@ public:
     *         make sure that the owning observable_unique_ptr will not be reset until
     *         you are done using the raw pointer.
     */
-    T* lock() const noexcept {
+    T* get() const noexcept {
         return std::weak_ptr<T>::lock().get();
     }
 
@@ -401,12 +401,12 @@ bool operator!= (std::nullptr_t, const observer_ptr<T>& value) noexcept {
 
 template<typename T, typename U>
 bool operator== (const observer_ptr<T>& first, const observer_ptr<U>& second) noexcept {
-    return first.lock() == second.lock();
+    return first.get() == second.get();
 }
 
 template<typename T, typename U>
 bool operator!= (const observer_ptr<T>& first, const observer_ptr<U>& second) noexcept {
-    return first.lock() != second.lock();
+    return first.get() != second.get();
 }
 
 }

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -374,6 +374,37 @@ public:
     weak_ptr& operator=(weak_ptr&&) noexcept = default;
 };
 
+
+template<typename T>
+bool operator== (const weak_ptr<T>& value, std::nullptr_t) noexcept {
+    return value.expired();
+}
+
+template<typename T>
+bool operator== (std::nullptr_t, const weak_ptr<T>& value) noexcept {
+    return value.expired();
+}
+
+template<typename T>
+bool operator!= (const weak_ptr<T>& value, std::nullptr_t) noexcept {
+    return !value.expired();
+}
+
+template<typename T>
+bool operator!= (std::nullptr_t, const weak_ptr<T>& value) noexcept {
+    return !value.expired();
+}
+
+template<typename T, typename U>
+bool operator== (const weak_ptr<T>& first, const weak_ptr<U>& second) noexcept {
+    return first.lock() == second.lock();
+}
+
+template<typename T, typename U>
+bool operator!= (const weak_ptr<T>& first, const weak_ptr<U>& second) noexcept {
+    return first.lock() != second.lock();
+}
+
 }
 
 #endif

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -66,13 +66,31 @@ private:
     friend class observer_ptr;
 
 public:
-    // Import members from std::shared_ptr
+    /// Type of the pointed object
     using typename std::shared_ptr<T>::element_type;
-    using weak_type = observer_ptr<T>;
 
+    /// Type of the matching observer pointer
+    using observer_type = observer_ptr<T>;
+
+    /// Get a non-owning raw pointer to the pointed object, or nullptr if none.
+    /** \return 'nullptr' if no object is owned, or the pointed object otherwise
+    */
     using std::shared_ptr<T>::get;
+
+    /// Get a reference to the pointed object (undefined behavior if nullptr).
+    /** \return A reference to the pointed object
+    *   \note Using this function if this pointer is null will leave to undefined behavior.
+    */
     using std::shared_ptr<T>::operator*;
+
+    /// Get a non-owning raw pointer to the pointed object, or nullptr if none.
+    /** \return 'nullptr' if no object is owned, or the pointed object otherwise
+    */
     using std::shared_ptr<T>::operator->;
+
+    /// Check if this pointer points to a valid object.
+    /** \return 'true' if the pointed object is valid, 'false' otherwise
+    */
     using std::shared_ptr<T>::operator bool;
 
     // Define member types for compatibility with std::unique_ptr
@@ -294,10 +312,15 @@ private:
     friend class observer_ptr;
 
 public:
-    // Import members from std::shared_ptr
+    /// Type of the pointed object
     using typename std::weak_ptr<T>::element_type;
 
+    /// Set this pointer to null.
     using std::weak_ptr<T>::reset;
+
+    /// Check if this pointer points to a valid object.
+    /** \return 'true' if the pointed object is valid, 'false' otherwise
+    */
     using std::weak_ptr<T>::expired;
 
     /// Default constructor (null pointer).

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -164,7 +164,7 @@ public:
 
     /// Explicit ownership capture of a raw pointer, with customer deleter.
     /** \param value The raw pointer to take ownership of
-    *   \param deleter The deleter object to use
+    *   \param del The deleter object to use
     *   \note Do *not* manually delete this raw pointer after the
     *         observable_unique_ptr is created. If possible, prefer
     *         using make_observable_unique() instead of this constructor.

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -302,11 +302,14 @@ public:
     /** \return A pointer to the un-managed object
     */
     T* release() noexcept {
+        T* old_ptr = pointer;
         if (pointer) {
             pop_ref_();
+            block = nullptr;
+            pointer = nullptr;
         }
 
-        return pointer;
+        return old_ptr;
     }
 
     /// Get a non-owning raw pointer to the pointed object, or nullptr if deleted.

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -12,7 +12,7 @@ class observer_ptr;
 
 namespace details {
 struct control_block {
-    std::size_t refcount = 1u;
+    int refcount = 1;
     bool placement_allocated = false;
     bool expired = false;
 };
@@ -60,7 +60,7 @@ private:
 
     static void pop_ref_(control_block* block) noexcept {
         --block->refcount;
-        if (block->refcount == 0u) {
+        if (block->refcount == 0) {
             if constexpr (std::is_same_v<Deleter, std::default_delete<T>>) {
                 if (block->placement_allocated) {
                     block->~control_block();
@@ -401,7 +401,7 @@ observable_unique_ptr<T> make_observable_unique(Args&& ... args) {
 
     try {
         // Construct control block and object
-        block_type* block = new (buffer) details::control_block{1u, true, false};
+        block_type* block = new (buffer) details::control_block{1, true, false};
         T* ptr = new (buffer + block_size) T(std::forward<Args>(args)...);
 
         // Make owner pointer
@@ -463,7 +463,7 @@ private:
 
     void pop_ref_() noexcept {
         --block->refcount;
-        if (block->refcount == 0u) {
+        if (block->refcount == 0) {
             if (block->placement_allocated) {
                 block->~control_block();
                 delete[] reinterpret_cast<std::byte*>(block);

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -303,8 +303,12 @@ public:
     /// Default constructor (null pointer).
     observer_ptr() = default;
 
+    /// Default constructor (null pointer).
+    observer_ptr(std::nullptr_t) {}
+
     /// Create a weak pointer from an owning pointer.
-    observer_ptr(const observable_unique_ptr<T>& owner) noexcept : std::weak_ptr<T>(owner) {}
+    template<typename U>
+    observer_ptr(const observable_unique_ptr<U>& owner) noexcept : std::weak_ptr<T>(owner) {}
 
     /// Copy an existing observer_ptr instance
     /** \param value The existing weak pointer to copy

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ function(run_compile_test TEST_NAME TEST_FILE EXPECTED)
   if (COMPILE_TEST_RESULT STREQUAL EXPECTED)
     message(STATUS "Test ${TEST_NAME} passed.")
   else()
-    message(SEND_ERROR "FAILED test: ${TEST_NAME}, expected ${EXPECTED} and got ${COMPILE_TEST_RESULT}")
+    message(WARNING "FAILED test: ${TEST_NAME}, expected ${EXPECTED} and got ${COMPILE_TEST_RESULT}")
   endif()
 endfunction()
 

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -529,6 +529,16 @@ TEST_CASE("owner dereference", "[owner_utility]") {
     REQUIRE((*ptr).state_ == 1337);
 }
 
+TEST_CASE("owner operator bool valid", "[owner_utility]") {
+    test_ptr ptr(new test_object);
+    if (ptr) {} else FAIL("if (ptr) should have been true");
+}
+
+TEST_CASE("owner operator bool invalid", "[owner_utility]") {
+    test_ptr ptr;
+    if (ptr) FAIL("if (ptr) should not have been true");
+}
+
 TEST_CASE("make observable", "[make_observable_unique]") {
     {
         test_ptr ptr = oup::make_observable_unique<test_object>();
@@ -754,6 +764,17 @@ TEST_CASE("observer dereference", "[observer_utility]") {
     test_optr ptr(ptr_owner);
     REQUIRE(ptr->state_ == 1337);
     REQUIRE((*ptr).state_ == 1337);
+}
+
+TEST_CASE("observer operator bool valid", "[observer_utility]") {
+    test_ptr ptr_owner(new test_object);
+    test_optr ptr(ptr_owner);
+    if (ptr) {} else FAIL("if (ptr) should have been true");
+}
+
+TEST_CASE("observer operator bool invalid", "[observer_utility]") {
+    test_optr ptr;
+    if (ptr) FAIL("if (ptr) should not have been true");
 }
 
 TEST_CASE("observer comparison valid ptr vs nullptr", "[observer_comparison]") {

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -730,3 +730,58 @@ TEST_CASE("observer swap two different instances", "[observer_utility]") {
 
     REQUIRE(instances == 0);
 }
+
+TEST_CASE("observer comparison valid ptr vs nullptr", "[observer_comparison]") {
+    test_ptr ptr_owner(new test_object);
+    test_wptr ptr(ptr_owner);
+    REQUIRE(ptr != nullptr);
+    REQUIRE(!(ptr == nullptr));
+    REQUIRE(nullptr != ptr);
+    REQUIRE(!(nullptr == ptr));
+}
+
+TEST_CASE("observer comparison invalid ptr vs nullptr", "[observer_comparison]") {
+    test_wptr ptr;
+    REQUIRE(ptr == nullptr);
+    REQUIRE(!(ptr != nullptr));
+    REQUIRE(nullptr == ptr);
+    REQUIRE(!(nullptr != ptr));
+}
+
+TEST_CASE("observer comparison invalid ptr vs invalid ptr", "[observer_comparison]") {
+    test_wptr ptr1;
+    test_wptr ptr2;
+    REQUIRE(ptr1 == ptr2);
+    REQUIRE(!(ptr1 != ptr2));
+}
+
+TEST_CASE("observer comparison invalid ptr vs valid ptr", "[observer_comparison]") {
+    test_ptr ptr_owner(new test_object);
+    test_wptr ptr1;
+    test_wptr ptr2(ptr_owner);
+    REQUIRE(ptr1 != ptr2);
+    REQUIRE(!(ptr1 == ptr2));
+    REQUIRE(ptr2 != ptr1);
+    REQUIRE(!(ptr2 == ptr1));
+}
+
+TEST_CASE("observer comparison valid ptr vs valid ptr same owner", "[observer_comparison]") {
+    test_ptr ptr_owner(new test_object);
+    test_wptr ptr1(ptr_owner);
+    test_wptr ptr2(ptr_owner);
+    REQUIRE(ptr1 == ptr2);
+    REQUIRE(!(ptr1 != ptr2));
+    REQUIRE(ptr2 == ptr1);
+    REQUIRE(!(ptr2 != ptr1));
+}
+
+TEST_CASE("observer comparison valid ptr vs valid ptr different owner", "[observer_comparison]") {
+    test_ptr ptr_owner1(new test_object);
+    test_ptr ptr_owner2(new test_object);
+    test_wptr ptr1(ptr_owner1);
+    test_wptr ptr2(ptr_owner2);
+    REQUIRE(ptr1 != ptr2);
+    REQUIRE(!(ptr1 == ptr2));
+    REQUIRE(ptr2 != ptr1);
+    REQUIRE(!(ptr2 == ptr1));
+}

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -132,7 +132,7 @@ TEST_CASE("owner implicit conversion constructor with deleter", "[owner_construc
             REQUIRE(instances_derived == 1);
             REQUIRE(instances_deleter == 2);
             REQUIRE(ptr.get() != nullptr);
-            REQUIRE(ptr.get_deleter().state_ == 0);
+            REQUIRE(ptr.get_deleter().state_ == 42);
         }
 
         REQUIRE(instances == 0);
@@ -164,7 +164,7 @@ TEST_CASE("owner explicit conversion constructor", "[owner_construction]") {
     REQUIRE(instances_derived == 0);
 }
 
-TEST_CASE("owner explicit conversion constructor with deleter", "[owner_construction]") {
+TEST_CASE("owner explicit conversion constructor with default deleter", "[owner_construction]") {
     {
         test_ptr_with_deleter ptr_orig{new test_object_derived, test_deleter{42}};
         {
@@ -175,6 +175,30 @@ TEST_CASE("owner explicit conversion constructor with deleter", "[owner_construc
             REQUIRE(instances_deleter == 2);
             REQUIRE(ptr.get() != nullptr);
             REQUIRE(ptr.get_deleter().state_ == 0);
+        }
+
+        REQUIRE(instances == 0);
+        REQUIRE(instances_derived == 0);
+        REQUIRE(instances_deleter == 1);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(instances_derived == 0);
+    REQUIRE(instances_deleter == 0);
+}
+
+TEST_CASE("owner explicit conversion constructor with custom deleter", "[owner_construction]") {
+    {
+        test_ptr_with_deleter ptr_orig{new test_object_derived, test_deleter{42}};
+        {
+            test_ptr_derived_with_deleter ptr(std::move(ptr_orig),
+                dynamic_cast<test_object_derived*>(ptr_orig.get()),
+                test_deleter{43});
+            REQUIRE(instances == 1);
+            REQUIRE(instances_derived == 1);
+            REQUIRE(instances_deleter == 2);
+            REQUIRE(ptr.get() != nullptr);
+            REQUIRE(ptr.get_deleter().state_ == 43);
         }
 
         REQUIRE(instances == 0);

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -71,7 +71,7 @@ TEST_CASE("owner move constructor with deleter", "[owner_construction]") {
             REQUIRE(instances == 1);
             REQUIRE(instances_deleter == 2);
             REQUIRE(ptr.get() != nullptr);
-            REQUIRE(ptr.get_deleter().state_ == 0);
+            REQUIRE(ptr.get_deleter().state_ == 42);
         }
 
         REQUIRE(instances == 0);
@@ -212,7 +212,7 @@ TEST_CASE("owner move assignment operator with deleter", "[owner_assignment]") {
             REQUIRE(instances == 1);
             REQUIRE(instances_deleter == 2);
             REQUIRE(ptr.get() != nullptr);
-            REQUIRE(ptr.get_deleter().state_ == 0);
+            REQUIRE(ptr.get_deleter().state_ == 42);
         }
 
         REQUIRE(instances == 0);

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -7,7 +7,6 @@ TEST_CASE("owner default constructor", "[owner_construction]") {
         test_ptr ptr{};
         REQUIRE(instances == 0);
         REQUIRE(ptr.get() == nullptr);
-        REQUIRE(ptr.has_deleter() == false);
     }
 
     REQUIRE(instances == 0);
@@ -19,7 +18,6 @@ TEST_CASE("owner default constructor with deleter", "[owner_construction]") {
         REQUIRE(instances == 0);
         REQUIRE(instances_deleter == 1);
         REQUIRE(ptr.get() == nullptr);
-        REQUIRE(ptr.has_deleter() == true);
         REQUIRE(ptr.get_deleter().state_ == 0);
     }
 
@@ -32,7 +30,6 @@ TEST_CASE("owner nullptr constructor", "[owner_construction]") {
         test_ptr ptr{nullptr};
         REQUIRE(instances == 0);
         REQUIRE(ptr.get() == nullptr);
-        REQUIRE(ptr.has_deleter() == false);
     }
 
     REQUIRE(instances == 0);
@@ -44,7 +41,6 @@ TEST_CASE("owner nullptr constructor with deleter", "[owner_construction]") {
         REQUIRE(instances == 0);
         REQUIRE(instances_deleter == 1);
         REQUIRE(ptr.get() == nullptr);
-        REQUIRE(ptr.has_deleter() == true);
         REQUIRE(ptr.get_deleter().state_ == 42);
     }
 
@@ -59,7 +55,6 @@ TEST_CASE("owner move constructor", "[owner_construction]") {
             test_ptr ptr(std::move(ptr_orig));
             REQUIRE(instances == 1);
             REQUIRE(ptr.get() != nullptr);
-            REQUIRE(ptr.has_deleter() == false);
         }
 
         REQUIRE(instances == 0);
@@ -74,14 +69,13 @@ TEST_CASE("owner move constructor with deleter", "[owner_construction]") {
         {
             test_ptr_with_deleter ptr(std::move(ptr_orig));
             REQUIRE(instances == 1);
-            REQUIRE(instances_deleter == 1);
+            REQUIRE(instances_deleter == 2);
             REQUIRE(ptr.get() != nullptr);
-            REQUIRE(ptr.has_deleter() == true);
-            REQUIRE(ptr.get_deleter().state_ == 42);
+            REQUIRE(ptr.get_deleter().state_ == 0);
         }
 
         REQUIRE(instances == 0);
-        REQUIRE(instances_deleter == 0);
+        REQUIRE(instances_deleter == 1);
     }
 
     REQUIRE(instances == 0);
@@ -93,7 +87,6 @@ TEST_CASE("owner acquiring constructor", "[owner_construction]") {
         test_ptr ptr{new test_object};
         REQUIRE(instances == 1);
         REQUIRE(ptr.get() != nullptr);
-        REQUIRE(ptr.has_deleter() == false);
     }
 
     REQUIRE(instances == 0);
@@ -105,7 +98,6 @@ TEST_CASE("owner acquiring constructor with deleter", "[owner_construction]") {
         REQUIRE(instances == 1);
         REQUIRE(instances_deleter == 1);
         REQUIRE(ptr.get() != nullptr);
-        REQUIRE(ptr.has_deleter() == true);
         REQUIRE(ptr.get_deleter().state_ == 42);
     }
 
@@ -121,7 +113,6 @@ TEST_CASE("owner implicit conversion constructor", "[owner_construction]") {
             REQUIRE(instances == 1);
             REQUIRE(instances_derived == 1);
             REQUIRE(ptr.get() != nullptr);
-            REQUIRE(ptr.has_deleter() == false);
         }
 
         REQUIRE(instances == 0);
@@ -139,15 +130,14 @@ TEST_CASE("owner implicit conversion constructor with deleter", "[owner_construc
             test_ptr_with_deleter ptr(std::move(ptr_orig));
             REQUIRE(instances == 1);
             REQUIRE(instances_derived == 1);
-            REQUIRE(instances_deleter == 1);
+            REQUIRE(instances_deleter == 2);
             REQUIRE(ptr.get() != nullptr);
-            REQUIRE(ptr.has_deleter() == true);
-            REQUIRE(ptr.get_deleter().state_ == 42);
+            REQUIRE(ptr.get_deleter().state_ == 0);
         }
 
         REQUIRE(instances == 0);
         REQUIRE(instances_derived == 0);
-        REQUIRE(instances_deleter == 0);
+        REQUIRE(instances_deleter == 1);
     }
 
     REQUIRE(instances == 0);
@@ -164,7 +154,6 @@ TEST_CASE("owner explicit conversion constructor", "[owner_construction]") {
             REQUIRE(instances == 1);
             REQUIRE(instances_derived == 1);
             REQUIRE(ptr.get() != nullptr);
-            REQUIRE(ptr.has_deleter() == false);
         }
 
         REQUIRE(instances == 0);
@@ -183,15 +172,14 @@ TEST_CASE("owner explicit conversion constructor with deleter", "[owner_construc
                 dynamic_cast<test_object_derived*>(ptr_orig.get()));
             REQUIRE(instances == 1);
             REQUIRE(instances_derived == 1);
-            REQUIRE(instances_deleter == 1);
+            REQUIRE(instances_deleter == 2);
             REQUIRE(ptr.get() != nullptr);
-            REQUIRE(ptr.has_deleter() == true);
-            REQUIRE(ptr.get_deleter().state_ == 42);
+            REQUIRE(ptr.get_deleter().state_ == 0);
         }
 
         REQUIRE(instances == 0);
         REQUIRE(instances_derived == 0);
-        REQUIRE(instances_deleter == 0);
+        REQUIRE(instances_deleter == 1);
     }
 
     REQUIRE(instances == 0);
@@ -207,7 +195,6 @@ TEST_CASE("owner move assignment operator", "[owner_assignment]") {
             ptr = std::move(ptr_orig);
             REQUIRE(instances == 1);
             REQUIRE(ptr.get() != nullptr);
-            REQUIRE(ptr.has_deleter() == false);
         }
 
         REQUIRE(instances == 0);
@@ -223,14 +210,13 @@ TEST_CASE("owner move assignment operator with deleter", "[owner_assignment]") {
             test_ptr_with_deleter ptr;
             ptr = std::move(ptr_orig);
             REQUIRE(instances == 1);
-            REQUIRE(instances_deleter == 1);
+            REQUIRE(instances_deleter == 2);
             REQUIRE(ptr.get() != nullptr);
-            REQUIRE(ptr.has_deleter() == true);
-            REQUIRE(ptr.get_deleter().state_ == 42);
+            REQUIRE(ptr.get_deleter().state_ == 0);
         }
 
         REQUIRE(instances == 0);
-        REQUIRE(instances_deleter == 0);
+        REQUIRE(instances_deleter == 1);
     }
 
     REQUIRE(instances == 0);
@@ -360,7 +346,6 @@ TEST_CASE("owner reset to null", "[owner_utility]") {
         ptr.reset();
         REQUIRE(instances == 0);
         REQUIRE(ptr.get() == nullptr);
-        REQUIRE(ptr.has_deleter() == false);
     }
 
     REQUIRE(instances == 0);
@@ -373,7 +358,6 @@ TEST_CASE("owner reset to null with deleter", "[owner_utility]") {
         REQUIRE(instances == 0);
         REQUIRE(instances_deleter == 1);
         REQUIRE(ptr.get() == nullptr);
-        REQUIRE(ptr.has_deleter() == true);
         REQUIRE(ptr.get_deleter().state_ == 42);
     }
 
@@ -387,7 +371,6 @@ TEST_CASE("owner reset to new", "[owner_utility]") {
         ptr.reset(new test_object);
         REQUIRE(instances == 1);
         REQUIRE(ptr.get() != nullptr);
-        REQUIRE(ptr.has_deleter() == false);
     }
 
     REQUIRE(instances == 0);
@@ -400,23 +383,7 @@ TEST_CASE("owner reset to new with deleter", "[owner_utility]") {
         REQUIRE(instances == 1);
         REQUIRE(instances_deleter == 1);
         REQUIRE(ptr.get() != nullptr);
-        REQUIRE(ptr.has_deleter() == true);
         REQUIRE(ptr.get_deleter().state_ == 42);
-    }
-
-    REQUIRE(instances == 0);
-    REQUIRE(instances_deleter == 0);
-}
-
-TEST_CASE("owner reset to new with new deleter", "[owner_utility]") {
-    {
-        test_ptr_with_deleter ptr(new test_object, test_deleter{42});
-        ptr.reset(new test_object, test_deleter{43});
-        REQUIRE(instances == 1);
-        REQUIRE(instances_deleter == 1);
-        REQUIRE(ptr.get() != nullptr);
-        REQUIRE(ptr.has_deleter() == true);
-        REQUIRE(ptr.get_deleter().state_ == 43);
     }
 
     REQUIRE(instances == 0);
@@ -445,8 +412,6 @@ TEST_CASE("owner swap no instance with deleter", "[owner_utility]") {
         REQUIRE(instances_deleter == 2);
         REQUIRE(ptr_orig.get() == nullptr);
         REQUIRE(ptr.get() == nullptr);
-        REQUIRE(ptr.has_deleter() == true);
-        REQUIRE(ptr_orig.has_deleter() == true);
         REQUIRE(ptr.get_deleter().state_ == 42);
         REQUIRE(ptr_orig.get_deleter().state_ == 43);
     }
@@ -477,8 +442,6 @@ TEST_CASE("owner swap one instance with deleter", "[owner_utility]") {
         REQUIRE(instances_deleter == 2);
         REQUIRE(ptr_orig.get() == nullptr);
         REQUIRE(ptr.get() != nullptr);
-        REQUIRE(ptr.has_deleter() == true);
-        REQUIRE(ptr_orig.has_deleter() == true);
         REQUIRE(ptr.get_deleter().state_ == 42);
         REQUIRE(ptr_orig.get_deleter().state_ == 43);
     }
@@ -513,8 +476,6 @@ TEST_CASE("owner swap two instances with deleter", "[owner_utility]") {
         REQUIRE(instances_deleter == 2);
         REQUIRE(ptr_orig.get() == ptr_raw);
         REQUIRE(ptr.get() == ptr_orig_raw);
-        REQUIRE(ptr.has_deleter() == true);
-        REQUIRE(ptr_orig.has_deleter() == true);
         REQUIRE(ptr.get_deleter().state_ == 42);
         REQUIRE(ptr_orig.get_deleter().state_ == 43);
     }
@@ -539,12 +500,62 @@ TEST_CASE("owner operator bool invalid", "[owner_utility]") {
     if (ptr) FAIL("if (ptr) should not have been true");
 }
 
+TEST_CASE("owner release valid", "[owner_utility]") {
+    {
+        test_ptr ptr(new test_object);
+        test_object* ptr_raw = ptr.release();
+        REQUIRE(ptr_raw != nullptr);
+        REQUIRE(ptr.get() == nullptr);
+        REQUIRE(instances == 1);
+        delete ptr_raw;
+    }
+
+    REQUIRE(instances == 0);
+}
+
+TEST_CASE("owner release valid with deleter", "[owner_utility]") {
+    {
+        test_ptr_with_deleter ptr(new test_object, test_deleter{42});
+        test_object* ptr_raw = ptr.release();
+        REQUIRE(ptr_raw != nullptr);
+        REQUIRE(ptr.get() == nullptr);
+        REQUIRE(instances == 1);
+        REQUIRE(instances_deleter == 1);
+        REQUIRE(ptr.get_deleter().state_ == 42);
+        delete ptr_raw;
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(instances_deleter == 0);
+}
+
+TEST_CASE("owner release invalid", "[owner_utility]") {
+    {
+        test_ptr ptr;
+        REQUIRE(ptr.release() == nullptr);
+        REQUIRE(instances == 0);
+    }
+
+    REQUIRE(instances == 0);
+}
+
+TEST_CASE("owner release invalid with deleter", "[owner_utility]") {
+    {
+        test_ptr_with_deleter ptr;
+        REQUIRE(ptr.release() == nullptr);
+        REQUIRE(instances == 0);
+        REQUIRE(instances_deleter == 1);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(instances_deleter == 1);
+}
+
 TEST_CASE("make observable", "[make_observable_unique]") {
     {
         test_ptr ptr = oup::make_observable_unique<test_object>();
         REQUIRE(instances == 1);
         REQUIRE(ptr.get() != nullptr);
-        REQUIRE(ptr.has_deleter() == false);
     }
 
     REQUIRE(instances == 0);

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -36,6 +36,7 @@ void operator delete(void* p) noexcept
         for (std::size_t i = 0; i < num_allocations; ++i) {
             if (allocations[i] == p) {
                 std::swap(allocations[i], allocations[num_allocations-1]);
+                --num_allocations;
                 found = true;
                 break;
             }
@@ -44,8 +45,6 @@ void operator delete(void* p) noexcept
         if (!found) {
             ++double_delete;
         }
-
-        --num_allocations;
     }
 
     std::free(p);

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -548,7 +548,7 @@ TEST_CASE("owner release invalid with deleter", "[owner_utility]") {
     }
 
     REQUIRE(instances == 0);
-    REQUIRE(instances_deleter == 1);
+    REQUIRE(instances_deleter == 0);
 }
 
 TEST_CASE("make observable", "[make_observable_unique]") {

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -544,7 +544,7 @@ TEST_CASE("make observable throw in constructor", "[make_observable_unique]") {
 
 TEST_CASE("observer default constructor", "[observer_construction]") {
     {
-        test_wptr ptr{};
+        test_optr ptr{};
         REQUIRE(instances == 0);
         REQUIRE(ptr.lock() == nullptr);
         REQUIRE(ptr.expired() == true);
@@ -555,7 +555,7 @@ TEST_CASE("observer default constructor", "[observer_construction]") {
 
 TEST_CASE("observer nullptr constructor", "[observer_construction]") {
     {
-        test_wptr ptr{nullptr};
+        test_optr ptr{nullptr};
         REQUIRE(instances == 0);
         REQUIRE(ptr.lock() == nullptr);
         REQUIRE(ptr.expired() == true);
@@ -567,9 +567,9 @@ TEST_CASE("observer nullptr constructor", "[observer_construction]") {
 TEST_CASE("observer move constructor", "[observer_construction]") {
     {
         test_ptr ptr_owner{new test_object};
-        test_wptr ptr_orig{ptr_owner};
+        test_optr ptr_orig{ptr_owner};
         {
-            test_wptr ptr(std::move(ptr_orig));
+            test_optr ptr(std::move(ptr_orig));
             REQUIRE(instances == 1);
             REQUIRE(ptr.lock() != nullptr);
             REQUIRE(ptr.expired() == false);
@@ -584,7 +584,7 @@ TEST_CASE("observer move constructor", "[observer_construction]") {
 TEST_CASE("observer acquiring constructor", "[observer_construction]") {
     {
         test_ptr ptr_owner{new test_object};
-        test_wptr ptr{ptr_owner};
+        test_optr ptr{ptr_owner};
         REQUIRE(instances == 1);
         REQUIRE(ptr.lock() != nullptr);
         REQUIRE(ptr.expired() == false);
@@ -596,9 +596,9 @@ TEST_CASE("observer acquiring constructor", "[observer_construction]") {
 TEST_CASE("observer implicit copy conversion constructor", "[observer_construction]") {
     {
         test_ptr_derived ptr_owner{new test_object_derived};
-        test_wptr_derived ptr_orig{ptr_owner};
+        test_optr_derived ptr_orig{ptr_owner};
         {
-            test_wptr ptr(ptr_orig);
+            test_optr ptr(ptr_orig);
             REQUIRE(instances == 1);
             REQUIRE(instances_derived == 1);
             REQUIRE(ptr.lock() != nullptr);
@@ -618,9 +618,9 @@ TEST_CASE("observer implicit copy conversion constructor", "[observer_constructi
 TEST_CASE("observer implicit move conversion constructor", "[observer_construction]") {
     {
         test_ptr_derived ptr_owner{new test_object_derived};
-        test_wptr_derived ptr_orig{ptr_owner};
+        test_optr_derived ptr_orig{ptr_owner};
         {
-            test_wptr ptr(std::move(ptr_orig));
+            test_optr ptr(std::move(ptr_orig));
             REQUIRE(instances == 1);
             REQUIRE(instances_derived == 1);
             REQUIRE(ptr.lock() != nullptr);
@@ -638,7 +638,7 @@ TEST_CASE("observer implicit move conversion constructor", "[observer_constructi
 }
 
 TEST_CASE("observer expiring", "[observer_utility]") {
-    test_wptr ptr;
+    test_optr ptr;
 
     {
         test_ptr ptr_owner{new test_object};
@@ -656,7 +656,7 @@ TEST_CASE("observer expiring", "[observer_utility]") {
 TEST_CASE("observer reset to null", "[observer_utility]") {
     {
         test_ptr ptr_owner(new test_object);
-        test_wptr ptr(ptr_owner);
+        test_optr ptr(ptr_owner);
         ptr.reset();
         REQUIRE(instances == 1);
         REQUIRE(ptr.lock() == nullptr);
@@ -669,8 +669,8 @@ TEST_CASE("observer reset to null", "[observer_utility]") {
 
 TEST_CASE("observer swap no instance", "[observer_utility]") {
     {
-        test_wptr ptr_orig;
-        test_wptr ptr;
+        test_optr ptr_orig;
+        test_optr ptr;
         ptr.swap(ptr_orig);
         REQUIRE(instances == 0);
         REQUIRE(ptr_orig.lock() == nullptr);
@@ -685,8 +685,8 @@ TEST_CASE("observer swap no instance", "[observer_utility]") {
 TEST_CASE("observer swap one instance", "[observer_utility]") {
     {
         test_ptr ptr_owner(new test_object);
-        test_wptr ptr_orig(ptr_owner);
-        test_wptr ptr;
+        test_optr ptr_orig(ptr_owner);
+        test_optr ptr;
         ptr.swap(ptr_orig);
         REQUIRE(instances == 1);
         REQUIRE(ptr_orig.lock() == nullptr);
@@ -701,8 +701,8 @@ TEST_CASE("observer swap one instance", "[observer_utility]") {
 TEST_CASE("observer swap two same instance", "[observer_utility]") {
     {
         test_ptr ptr_owner(new test_object);
-        test_wptr ptr_orig(ptr_owner);
-        test_wptr ptr(ptr_owner);
+        test_optr ptr_orig(ptr_owner);
+        test_optr ptr(ptr_owner);
         ptr.swap(ptr_orig);
         REQUIRE(instances == 1);
         REQUIRE(ptr_orig.lock() == ptr_owner.get());
@@ -718,8 +718,8 @@ TEST_CASE("observer swap two different instances", "[observer_utility]") {
     {
         test_ptr ptr_owner1(new test_object);
         test_ptr ptr_owner2(new test_object);
-        test_wptr ptr_orig(ptr_owner1);
-        test_wptr ptr(ptr_owner2);
+        test_optr ptr_orig(ptr_owner1);
+        test_optr ptr(ptr_owner2);
         ptr.swap(ptr_orig);
         REQUIRE(instances == 2);
         REQUIRE(ptr_orig.lock() == ptr_owner2.get());
@@ -733,7 +733,7 @@ TEST_CASE("observer swap two different instances", "[observer_utility]") {
 
 TEST_CASE("observer comparison valid ptr vs nullptr", "[observer_comparison]") {
     test_ptr ptr_owner(new test_object);
-    test_wptr ptr(ptr_owner);
+    test_optr ptr(ptr_owner);
     REQUIRE(ptr != nullptr);
     REQUIRE(!(ptr == nullptr));
     REQUIRE(nullptr != ptr);
@@ -741,7 +741,7 @@ TEST_CASE("observer comparison valid ptr vs nullptr", "[observer_comparison]") {
 }
 
 TEST_CASE("observer comparison invalid ptr vs nullptr", "[observer_comparison]") {
-    test_wptr ptr;
+    test_optr ptr;
     REQUIRE(ptr == nullptr);
     REQUIRE(!(ptr != nullptr));
     REQUIRE(nullptr == ptr);
@@ -749,16 +749,16 @@ TEST_CASE("observer comparison invalid ptr vs nullptr", "[observer_comparison]")
 }
 
 TEST_CASE("observer comparison invalid ptr vs invalid ptr", "[observer_comparison]") {
-    test_wptr ptr1;
-    test_wptr ptr2;
+    test_optr ptr1;
+    test_optr ptr2;
     REQUIRE(ptr1 == ptr2);
     REQUIRE(!(ptr1 != ptr2));
 }
 
 TEST_CASE("observer comparison invalid ptr vs valid ptr", "[observer_comparison]") {
     test_ptr ptr_owner(new test_object);
-    test_wptr ptr1;
-    test_wptr ptr2(ptr_owner);
+    test_optr ptr1;
+    test_optr ptr2(ptr_owner);
     REQUIRE(ptr1 != ptr2);
     REQUIRE(!(ptr1 == ptr2));
     REQUIRE(ptr2 != ptr1);
@@ -767,8 +767,8 @@ TEST_CASE("observer comparison invalid ptr vs valid ptr", "[observer_comparison]
 
 TEST_CASE("observer comparison valid ptr vs valid ptr same owner", "[observer_comparison]") {
     test_ptr ptr_owner(new test_object);
-    test_wptr ptr1(ptr_owner);
-    test_wptr ptr2(ptr_owner);
+    test_optr ptr1(ptr_owner);
+    test_optr ptr2(ptr_owner);
     REQUIRE(ptr1 == ptr2);
     REQUIRE(!(ptr1 != ptr2));
     REQUIRE(ptr2 == ptr1);
@@ -778,8 +778,8 @@ TEST_CASE("observer comparison valid ptr vs valid ptr same owner", "[observer_co
 TEST_CASE("observer comparison valid ptr vs valid ptr different owner", "[observer_comparison]") {
     test_ptr ptr_owner1(new test_object);
     test_ptr ptr_owner2(new test_object);
-    test_wptr ptr1(ptr_owner1);
-    test_wptr ptr2(ptr_owner2);
+    test_optr ptr1(ptr_owner1);
+    test_optr ptr2(ptr_owner2);
     REQUIRE(ptr1 != ptr2);
     REQUIRE(!(ptr1 == ptr2));
     REQUIRE(ptr2 != ptr1);

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -546,7 +546,7 @@ TEST_CASE("observer default constructor", "[observer_construction]") {
     {
         test_optr ptr{};
         REQUIRE(instances == 0);
-        REQUIRE(ptr.lock() == nullptr);
+        REQUIRE(ptr.get() == nullptr);
         REQUIRE(ptr.expired() == true);
     }
 
@@ -557,7 +557,7 @@ TEST_CASE("observer nullptr constructor", "[observer_construction]") {
     {
         test_optr ptr{nullptr};
         REQUIRE(instances == 0);
-        REQUIRE(ptr.lock() == nullptr);
+        REQUIRE(ptr.get() == nullptr);
         REQUIRE(ptr.expired() == true);
     }
 
@@ -571,7 +571,7 @@ TEST_CASE("observer move constructor", "[observer_construction]") {
         {
             test_optr ptr(std::move(ptr_orig));
             REQUIRE(instances == 1);
-            REQUIRE(ptr.lock() != nullptr);
+            REQUIRE(ptr.get() != nullptr);
             REQUIRE(ptr.expired() == false);
         }
 
@@ -586,7 +586,7 @@ TEST_CASE("observer acquiring constructor", "[observer_construction]") {
         test_ptr ptr_owner{new test_object};
         test_optr ptr{ptr_owner};
         REQUIRE(instances == 1);
-        REQUIRE(ptr.lock() != nullptr);
+        REQUIRE(ptr.get() != nullptr);
         REQUIRE(ptr.expired() == false);
     }
 
@@ -598,7 +598,7 @@ TEST_CASE("observer acquiring constructor derived", "[observer_construction]") {
         test_ptr_derived ptr_owner{new test_object_derived};
         test_optr ptr{ptr_owner};
         REQUIRE(instances == 1);
-        REQUIRE(ptr.lock() != nullptr);
+        REQUIRE(ptr.get() != nullptr);
         REQUIRE(ptr.expired() == false);
     }
 
@@ -613,13 +613,13 @@ TEST_CASE("observer implicit copy conversion constructor", "[observer_constructi
             test_optr ptr(ptr_orig);
             REQUIRE(instances == 1);
             REQUIRE(instances_derived == 1);
-            REQUIRE(ptr.lock() != nullptr);
+            REQUIRE(ptr.get() != nullptr);
             REQUIRE(ptr.expired() == false);
         }
 
         REQUIRE(instances == 1);
         REQUIRE(instances_derived == 1);
-        REQUIRE(ptr_orig.lock() != nullptr);
+        REQUIRE(ptr_orig.get() != nullptr);
         REQUIRE(ptr_orig.expired() == false);
     }
 
@@ -635,13 +635,13 @@ TEST_CASE("observer implicit move conversion constructor", "[observer_constructi
             test_optr ptr(std::move(ptr_orig));
             REQUIRE(instances == 1);
             REQUIRE(instances_derived == 1);
-            REQUIRE(ptr.lock() != nullptr);
+            REQUIRE(ptr.get() != nullptr);
             REQUIRE(ptr.expired() == false);
         }
 
         REQUIRE(instances == 1);
         REQUIRE(instances_derived == 1);
-        REQUIRE(ptr_orig.lock() == nullptr);
+        REQUIRE(ptr_orig.get() == nullptr);
         REQUIRE(ptr_orig.expired() == true);
     }
 
@@ -656,12 +656,12 @@ TEST_CASE("observer expiring", "[observer_utility]") {
         test_ptr ptr_owner{new test_object};
         ptr = ptr_owner;
         REQUIRE(instances == 1);
-        REQUIRE(ptr.lock() != nullptr);
+        REQUIRE(ptr.get() != nullptr);
         REQUIRE(ptr.expired() == false);
     }
 
     REQUIRE(instances == 0);
-    REQUIRE(ptr.lock() == nullptr);
+    REQUIRE(ptr.get() == nullptr);
     REQUIRE(ptr.expired() == true);
 }
 
@@ -671,7 +671,7 @@ TEST_CASE("observer reset to null", "[observer_utility]") {
         test_optr ptr(ptr_owner);
         ptr.reset();
         REQUIRE(instances == 1);
-        REQUIRE(ptr.lock() == nullptr);
+        REQUIRE(ptr.get() == nullptr);
         REQUIRE(ptr.expired() == true);
     }
 
@@ -685,8 +685,8 @@ TEST_CASE("observer swap no instance", "[observer_utility]") {
         test_optr ptr;
         ptr.swap(ptr_orig);
         REQUIRE(instances == 0);
-        REQUIRE(ptr_orig.lock() == nullptr);
-        REQUIRE(ptr.lock() == nullptr);
+        REQUIRE(ptr_orig.get() == nullptr);
+        REQUIRE(ptr.get() == nullptr);
         REQUIRE(ptr_orig.expired() == true);
         REQUIRE(ptr.expired() == true);
     }
@@ -701,8 +701,8 @@ TEST_CASE("observer swap one instance", "[observer_utility]") {
         test_optr ptr;
         ptr.swap(ptr_orig);
         REQUIRE(instances == 1);
-        REQUIRE(ptr_orig.lock() == nullptr);
-        REQUIRE(ptr.lock() != nullptr);
+        REQUIRE(ptr_orig.get() == nullptr);
+        REQUIRE(ptr.get() != nullptr);
         REQUIRE(ptr_orig.expired() == true);
         REQUIRE(ptr.expired() == false);
     }
@@ -717,8 +717,8 @@ TEST_CASE("observer swap two same instance", "[observer_utility]") {
         test_optr ptr(ptr_owner);
         ptr.swap(ptr_orig);
         REQUIRE(instances == 1);
-        REQUIRE(ptr_orig.lock() == ptr_owner.get());
-        REQUIRE(ptr.lock() == ptr_owner.get());
+        REQUIRE(ptr_orig.get() == ptr_owner.get());
+        REQUIRE(ptr.get() == ptr_owner.get());
         REQUIRE(ptr_orig.expired() == false);
         REQUIRE(ptr.expired() == false);
     }
@@ -734,8 +734,8 @@ TEST_CASE("observer swap two different instances", "[observer_utility]") {
         test_optr ptr(ptr_owner2);
         ptr.swap(ptr_orig);
         REQUIRE(instances == 2);
-        REQUIRE(ptr_orig.lock() == ptr_owner2.get());
-        REQUIRE(ptr.lock() == ptr_owner1.get());
+        REQUIRE(ptr_orig.get() == ptr_owner2.get());
+        REQUIRE(ptr.get() == ptr_owner1.get());
         REQUIRE(ptr_orig.expired() == false);
         REQUIRE(ptr.expired() == false);
     }

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -10,6 +10,8 @@ std::size_t num_allocations = 0u;
 std::size_t double_delete = 0u;
 bool memory_tracking = false;
 
+// NB: getting weird errors on MacOS when doing this
+#if !defined(__APPLE__)
 void* operator new(size_t size)
 {
     if (memory_tracking && num_allocations == max_allocations) {
@@ -49,6 +51,7 @@ void operator delete(void* p) noexcept
 
     std::free(p);
 }
+#endif
 
 struct memory_tracker {
     std::size_t initial_allocations;

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -237,6 +237,123 @@ TEST_CASE("owner move assignment operator with deleter", "[owner_assignment]") {
     REQUIRE(instances_deleter == 0);
 }
 
+TEST_CASE("owner comparison valid ptr vs nullptr", "[owner_comparison]") {
+    test_ptr ptr(new test_object);
+    REQUIRE(ptr != nullptr);
+    REQUIRE(!(ptr == nullptr));
+    REQUIRE(nullptr != ptr);
+    REQUIRE(!(nullptr == ptr));
+}
+
+TEST_CASE("owner comparison valid ptr vs nullptr with deleter", "[owner_comparison]") {
+    test_ptr_with_deleter ptr(new test_object, test_deleter{42});
+    REQUIRE(ptr != nullptr);
+    REQUIRE(!(ptr == nullptr));
+    REQUIRE(nullptr != ptr);
+    REQUIRE(!(nullptr == ptr));
+}
+
+TEST_CASE("owner comparison invalid ptr vs nullptr", "[owner_comparison]") {
+    test_ptr ptr;
+    REQUIRE(ptr == nullptr);
+    REQUIRE(!(ptr != nullptr));
+    REQUIRE(nullptr == ptr);
+    REQUIRE(!(nullptr != ptr));
+}
+
+TEST_CASE("owner comparison invalid ptr vs nullptr with deleter", "[owner_comparison]") {
+    test_ptr_with_deleter ptr;
+    REQUIRE(ptr == nullptr);
+    REQUIRE(!(ptr != nullptr));
+    REQUIRE(nullptr == ptr);
+    REQUIRE(!(nullptr != ptr));
+}
+
+TEST_CASE("owner comparison invalid ptr vs nullptr with deleter explicit", "[owner_comparison]") {
+    test_ptr_with_deleter ptr(nullptr, test_deleter{42});
+    REQUIRE(ptr == nullptr);
+    REQUIRE(!(ptr != nullptr));
+    REQUIRE(nullptr == ptr);
+    REQUIRE(!(nullptr != ptr));
+}
+
+TEST_CASE("owner comparison invalid ptr vs invalid ptr", "[owner_comparison]") {
+    test_ptr ptr1;
+    test_ptr ptr2;
+    REQUIRE(ptr1 == ptr2);
+    REQUIRE(!(ptr1 != ptr2));
+}
+
+TEST_CASE("owner comparison invalid ptr vs invalid ptr with deleter", "[owner_comparison]") {
+    test_ptr_with_deleter ptr1;
+    test_ptr_with_deleter ptr2;
+    REQUIRE(ptr1 == ptr2);
+    REQUIRE(!(ptr1 != ptr2));
+}
+
+TEST_CASE("owner comparison invalid ptr vs invalid ptr with deleter explicit", "[owner_comparison]") {
+    test_ptr_with_deleter ptr1;
+    test_ptr_with_deleter ptr2(nullptr, test_deleter{42});
+    REQUIRE(ptr1 == ptr2);
+    REQUIRE(ptr2 == ptr1);
+    REQUIRE(!(ptr2 != ptr1));
+    REQUIRE(!(ptr2 != ptr1));
+}
+
+TEST_CASE("owner comparison invalid ptr vs invalid ptr with both deleter explicit", "[owner_comparison]") {
+    test_ptr_with_deleter ptr1(nullptr, test_deleter{43});
+    test_ptr_with_deleter ptr2(nullptr, test_deleter{42});
+    REQUIRE(ptr1 == ptr2);
+    REQUIRE(ptr2 == ptr1);
+    REQUIRE(!(ptr2 != ptr1));
+    REQUIRE(!(ptr2 != ptr1));
+}
+
+TEST_CASE("owner comparison invalid ptr vs valid ptr", "[owner_comparison]") {
+    test_ptr ptr1;
+    test_ptr ptr2(new test_object);
+    REQUIRE(ptr1 != ptr2);
+    REQUIRE(!(ptr1 == ptr2));
+    REQUIRE(ptr2 != ptr1);
+    REQUIRE(!(ptr2 == ptr1));
+}
+
+TEST_CASE("owner comparison invalid ptr vs valid ptr with deleter", "[owner_comparison]") {
+    test_ptr_with_deleter ptr1;
+    test_ptr_with_deleter ptr2(new test_object, test_deleter{42});
+    REQUIRE(ptr1 != ptr2);
+    REQUIRE(!(ptr1 == ptr2));
+    REQUIRE(ptr2 != ptr1);
+    REQUIRE(!(ptr2 == ptr1));
+}
+
+TEST_CASE("owner comparison invalid ptr vs valid ptr with deleter explicit", "[owner_comparison]") {
+    test_ptr_with_deleter ptr1(nullptr, test_deleter{43});
+    test_ptr_with_deleter ptr2(new test_object, test_deleter{42});
+    REQUIRE(ptr1 != ptr2);
+    REQUIRE(!(ptr1 == ptr2));
+    REQUIRE(ptr2 != ptr1);
+    REQUIRE(!(ptr2 == ptr1));
+}
+
+TEST_CASE("owner comparison valid ptr vs valid ptr", "[owner_comparison]") {
+    test_ptr ptr1(new test_object);
+    test_ptr ptr2(new test_object);
+    REQUIRE(ptr1 != ptr2);
+    REQUIRE(!(ptr1 == ptr2));
+    REQUIRE(ptr2 != ptr1);
+    REQUIRE(!(ptr2 == ptr1));
+}
+
+TEST_CASE("owner comparison valid ptr vs valid ptr with deleter", "[owner_comparison]") {
+    test_ptr_with_deleter ptr1(new test_object, test_deleter{43});
+    test_ptr_with_deleter ptr2(new test_object, test_deleter{42});
+    REQUIRE(ptr1 != ptr2);
+    REQUIRE(!(ptr1 == ptr2));
+    REQUIRE(ptr2 != ptr1);
+    REQUIRE(!(ptr2 == ptr1));
+}
+
 TEST_CASE("owner reset to null", "[owner_utility]") {
     {
         test_ptr ptr(new test_object);

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -785,3 +785,25 @@ TEST_CASE("observer comparison valid ptr vs valid ptr different owner", "[observ
     REQUIRE(ptr2 != ptr1);
     REQUIRE(!(ptr2 == ptr1));
 }
+
+TEST_CASE("observer comparison valid ptr vs valid ptr same owner derived", "[observer_comparison]") {
+    test_ptr_derived ptr_owner(new test_object_derived);
+    test_optr ptr1(ptr_owner);
+    test_optr_derived ptr2(ptr_owner);
+    REQUIRE(ptr1 == ptr2);
+    REQUIRE(!(ptr1 != ptr2));
+    REQUIRE(ptr2 == ptr1);
+    REQUIRE(!(ptr2 != ptr1));
+}
+
+TEST_CASE("observer comparison valid ptr vs valid ptr different owner derived", "[observer_comparison]") {
+    test_ptr ptr_owner1(new test_object);
+    test_ptr_derived ptr_owner2(new test_object_derived);
+    test_optr ptr1(ptr_owner1);
+    test_optr_derived ptr2(ptr_owner2);
+    REQUIRE(ptr1 != ptr2);
+    REQUIRE(!(ptr1 == ptr2));
+    REQUIRE(ptr2 != ptr1);
+    REQUIRE(!(ptr2 == ptr1));
+}
+

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -593,6 +593,18 @@ TEST_CASE("observer acquiring constructor", "[observer_construction]") {
     REQUIRE(instances == 0);
 }
 
+TEST_CASE("observer acquiring constructor derived", "[observer_construction]") {
+    {
+        test_ptr_derived ptr_owner{new test_object_derived};
+        test_optr ptr{ptr_owner};
+        REQUIRE(instances == 1);
+        REQUIRE(ptr.lock() != nullptr);
+        REQUIRE(ptr.expired() == false);
+    }
+
+    REQUIRE(instances == 0);
+}
+
 TEST_CASE("observer implicit copy conversion constructor", "[observer_construction]") {
     {
         test_ptr_derived ptr_owner{new test_object_derived};

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -523,6 +523,12 @@ TEST_CASE("owner swap two instances with deleter", "[owner_utility]") {
     REQUIRE(instances_deleter == 0);
 }
 
+TEST_CASE("owner dereference", "[owner_utility]") {
+    test_ptr ptr(new test_object);
+    REQUIRE(ptr->state_ == 1337);
+    REQUIRE((*ptr).state_ == 1337);
+}
+
 TEST_CASE("make observable", "[make_observable_unique]") {
     {
         test_ptr ptr = oup::make_observable_unique<test_object>();
@@ -741,6 +747,13 @@ TEST_CASE("observer swap two different instances", "[observer_utility]") {
     }
 
     REQUIRE(instances == 0);
+}
+
+TEST_CASE("observer dereference", "[observer_utility]") {
+    test_ptr ptr_owner(new test_object);
+    test_optr ptr(ptr_owner);
+    REQUIRE(ptr->state_ == 1337);
+    REQUIRE((*ptr).state_ == 1337);
 }
 
 TEST_CASE("observer comparison valid ptr vs nullptr", "[observer_comparison]") {

--- a/tests/tests_common.hpp
+++ b/tests/tests_common.hpp
@@ -69,5 +69,5 @@ using test_ptr_derived_with_deleter = oup::observable_unique_ptr<test_object_der
 using test_ptr_thrower = oup::observable_unique_ptr<test_object_thrower>;
 using test_ptr_thrower_with_deleter = oup::observable_unique_ptr<test_object_thrower,test_deleter>;
 
-using test_wptr = oup::weak_ptr<test_object>;
-using test_wptr_derived = oup::weak_ptr<test_object_derived>;
+using test_optr = oup::observer_ptr<test_object>;
+using test_optr_derived = oup::observer_ptr<test_object_derived>;

--- a/tests/tests_common.hpp
+++ b/tests/tests_common.hpp
@@ -41,19 +41,19 @@ struct test_object_thrower {
 struct test_deleter {
     int state_ = 0;
 
-    test_deleter() { ++instances_deleter; }
-    explicit test_deleter(int state) : state_(state) { ++instances_deleter; }
+    test_deleter() noexcept { ++instances_deleter; }
+    explicit test_deleter(int state) noexcept : state_(state) { ++instances_deleter; }
 
-    test_deleter(const test_deleter& source) : state_(source.state_) { ++instances_deleter; }
-    test_deleter(test_deleter&& source) : state_(source.state_) {
+    test_deleter(const test_deleter& source) noexcept : state_(source.state_) { ++instances_deleter; }
+    test_deleter(test_deleter&& source) noexcept : state_(source.state_) {
         source.state_ = 0;
         ++instances_deleter;
     }
 
-    ~test_deleter() { --instances_deleter; }
+    ~test_deleter() noexcept { --instances_deleter; }
 
     test_deleter& operator=(const test_deleter&) = default;
-    test_deleter& operator=(test_deleter&& source) {
+    test_deleter& operator=(test_deleter&& source) noexcept {
         state_ = source.state_;
         source.state_ = 0;
         return *this;

--- a/tests/tests_common.hpp
+++ b/tests/tests_common.hpp
@@ -8,6 +8,8 @@ int instances_thrower = 0;
 int instances_deleter = 0;
 
 struct test_object {
+    int state_ = 1337;
+
     test_object() noexcept { ++instances; }
     virtual ~test_object() noexcept { --instances; }
 


### PR DESCRIPTION
This set of changes implements feedback received on [reddit](https://www.reddit.com/r/cpp/comments/qkblhp/a_uniqueownership_smart_pointer_that_can_be/):
 - remove limitations and inefficiencies caused by inheriting from `std::shared_ptr`
 - rename `weak_ptr` to `observer_ptr`
 - rename `observer_ptr::lock` into `observer_ptr::get` and just allow de-referencing 

Additional changes:
 - fixed operator== not compiling for `observable_unique_ptr`
 - fixed `observer_ptr` not constructible from derived type
 - added memory leak tests
 - added missing comparison operators for `observer_ptr`
 - added missing `operator bool()`