### PR TITLE
Introduce `observable_sealed_ptr`, improve memory footprint in C++17

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,7 +3,6 @@ name: CI
 on: [push, pull_request]
 
 env:
-  BUILD_TYPE: Release
   EM_VERSION: 2.0.16
   EM_CACHE_FOLDER: 'emsdk-cache'
 
@@ -19,8 +18,11 @@ jobs:
         - { name: Windows 64,   os: windows-latest, compiler: vs2019,  arch: "64", cmakepp: "",        flags: "-A x64"}
         - { name: MacOS,        os: macos-latest,   compiler: clang++, arch: "64", cmakepp: "",        flags: ""}
         - { name: WebAssembly,  os: ubuntu-latest,  compiler: em++,    arch: "32", cmakepp: "emcmake", flags: "-DCMAKE_CXX_FLAGS=\"-s DISABLE_EXCEPTION_CATCHING=0\" -DCMAKE_CROSSCOMPILING_EMULATOR=node"}
+        build-type:
+        - Release
+        - Debug
 
-    name: ${{matrix.platform.name}}
+    name: ${{matrix.platform.name}} ${{matrix.build-type}}
     runs-on: ${{matrix.platform.os}}
 
     steps:
@@ -54,12 +56,12 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${{matrix.platform.flags}} -DOUP_DO_TEST=1
+      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.platform.flags}} -DOUP_DO_TEST=1
 
     - name: Build
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: cmake --build . --config ${BUILD_TYPE} --parallel 2
+      run: cmake --build . --config ${{matrix.build-type}} --parallel 2
 
     - name: Test
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -64,5 +64,5 @@ jobs:
     - name: Test
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: ctest
+      run: ctest --output-on-failure
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,11 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Ubuntu GCC,   os: ubuntu-latest,  compiler: g++,     arch: "64", flags: ""}
-        - { name: Ubuntu Clang, os: ubuntu-latest,  compiler: clang++, arch: "64", flags: ""}
-        - { name: Windows 32,   os: windows-latest, compiler: vs2019,  arch: "32", flags: "-A Win32"}
-        - { name: Windows 64,   os: windows-latest, compiler: vs2019,  arch: "64", flags: "-A x64"}
-        - { name: MacOS,        os: macos-latest,   compiler: clang++, arch: "64", flags: ""}
+        - { name: Ubuntu GCC,   os: ubuntu-latest,  compiler: g++,     arch: "64", cmakepp: "",        flags: ""}
+        - { name: Ubuntu Clang, os: ubuntu-latest,  compiler: clang++, arch: "64", cmakepp: "",        flags: ""}
+        - { name: Windows 32,   os: windows-latest, compiler: vs2019,  arch: "32", cmakepp: "",        flags: "-A Win32"}
+        - { name: Windows 64,   os: windows-latest, compiler: vs2019,  arch: "64", cmakepp: "",        flags: "-A x64"}
+        - { name: MacOS,        os: macos-latest,   compiler: clang++, arch: "64", cmakepp: "",        flags: ""}
+        - { name: WebAssembly,  os: ubuntu-latest,  compiler: em++,    arch: "64", cmakepp: "emcmake", flags: "-DCMAKE_CXX_FLAGS=\"-s DISABLE_EXCEPTION_CATCHING=0\" -DCMAKE_CROSS_COMPILING_EMULATOR=node"}
 
     name: ${{matrix.platform.name}}
     runs-on: ${{matrix.platform.os}}
@@ -30,18 +31,37 @@ jobs:
       if: runner.os == 'Linux'
       run: export CXX=${{matrix.platform.compiler}}
 
+    - name: Setup Emscripten cache
+      if: matrix.platform.compiler == 'em++'
+      id: cache-system-libraries
+      uses: actions/cache@v2
+      with:
+        path: ${{env.EM_CACHE_FOLDER}}
+        key: ${{env.EM_VERSION}}-${{ runner.os }}
+
+    - name: Setup Emscripten
+      if: matrix.platform.compiler == 'em++'
+      uses: mymindstorm/setup-emsdk@v7
+      with:
+        version: ${{env.EM_VERSION}}
+        actions-cache-folder: ${{env.EM_CACHE_FOLDER}}
+
     - name: Create Build Environment
       run: cmake -E make_directory ${{github.workspace}}/build
 
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${{matrix.platform.flags}} -DOUP_DO_TEST=1
+      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${{matrix.platform.flags}} -DOUP_DO_TEST=1
 
     - name: Build
       shell: bash
       working-directory: ${{github.workspace}}/build
       run: cmake --build . --config ${BUILD_TYPE} --parallel 2
+
+    - name: Setup Node.js
+      if: matrix.platform.compiler == 'em++'
+      run: sudo apt install nodejs
 
     - name: Test
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 
 env:
   BUILD_TYPE: Release
+  EM_VERSION: 2.0.16
+  EM_CACHE_FOLDER: 'emsdk-cache'
 
 jobs:
   build:
@@ -16,7 +18,7 @@ jobs:
         - { name: Windows 32,   os: windows-latest, compiler: vs2019,  arch: "32", cmakepp: "",        flags: "-A Win32"}
         - { name: Windows 64,   os: windows-latest, compiler: vs2019,  arch: "64", cmakepp: "",        flags: "-A x64"}
         - { name: MacOS,        os: macos-latest,   compiler: clang++, arch: "64", cmakepp: "",        flags: ""}
-        - { name: WebAssembly,  os: ubuntu-latest,  compiler: em++,    arch: "64", cmakepp: "emcmake", flags: "-DCMAKE_CXX_FLAGS=\"-s DISABLE_EXCEPTION_CATCHING=0\" -DCMAKE_CROSS_COMPILING_EMULATOR=node"}
+        - { name: WebAssembly,  os: ubuntu-latest,  compiler: em++,    arch: "64", cmakepp: "emcmake", flags: "-DCMAKE_CXX_FLAGS=\"-s DISABLE_EXCEPTION_CATCHING=0\" -DCMAKE_CROSSCOMPILING_EMULATOR=node"}
 
     name: ${{matrix.platform.name}}
     runs-on: ${{matrix.platform.os}}
@@ -58,10 +60,6 @@ jobs:
       shell: bash
       working-directory: ${{github.workspace}}/build
       run: cmake --build . --config ${BUILD_TYPE} --parallel 2
-
-    - name: Setup Node.js
-      if: matrix.platform.compiler == 'em++'
-      run: sudo apt install nodejs
 
     - name: Test
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,7 @@ jobs:
         - { name: Windows 32,   os: windows-latest, compiler: vs2019,  arch: "32", cmakepp: "",        flags: "-A Win32"}
         - { name: Windows 64,   os: windows-latest, compiler: vs2019,  arch: "64", cmakepp: "",        flags: "-A x64"}
         - { name: MacOS,        os: macos-latest,   compiler: clang++, arch: "64", cmakepp: "",        flags: ""}
-        - { name: WebAssembly,  os: ubuntu-latest,  compiler: em++,    arch: "64", cmakepp: "emcmake", flags: "-DCMAKE_CXX_FLAGS=\"-s DISABLE_EXCEPTION_CATCHING=0\" -DCMAKE_CROSSCOMPILING_EMULATOR=node"}
+        - { name: WebAssembly,  os: ubuntu-latest,  compiler: em++,    arch: "32", cmakepp: "emcmake", flags: "-DCMAKE_CXX_FLAGS=\"-s DISABLE_EXCEPTION_CATCHING=0\" -DCMAKE_CROSSCOMPILING_EMULATOR=node"}
 
     name: ${{matrix.platform.name}}
     runs-on: ${{matrix.platform.os}}

--- a/README.md
+++ b/README.md
@@ -122,27 +122,27 @@ Notes:
 
 ## Speed benchmarks
 
-Labels are the same as in the comparison spreadsheet. The speed benchmarks were compiled with gcc 9.3.0 and libstdc++, with all optimizations turned on (except LTO), and run on a linux (5.1.0-89) machine with a Ryzen 5 2600 CPU. Speed is measured relative to `std::unique_ptr<T>` used as owner pointer, and `T*` used as observer pointer.
+Labels are the same as in the comparison spreadsheet. The speed benchmarks were compiled with gcc 9.3.0 and libstdc++, with all optimizations turned on (except LTO), and run on a linux (5.1.0-89) machine with a Ryzen 5 2600 CPU. Speed is measured relative to `std::unique_ptr<T>` used as owner pointer, and `T*` used as observer pointer, which should be the fastest possible implementation (but obviously the one with least safety).
 
-You can run the benchmarks yourself, they are located in `tests/speed_benchmark.cpp`. The benchmark executable runs tests for three object types: `int`, `std::string`, and `std::array<int,65'536>`, to simulate objects of various allocation cost. The timings below are reported for `int`, which should be most relevant to highlight the overhead from the pointer itself. In real life scenarios, the actual measured overhead will be substantially lower, as actual business logic is likely to dominate the time budget.
+You can run the benchmarks yourself, they are located in `tests/speed_benchmark.cpp`. The benchmark executable runs tests for three object types: `int`, `float`, `std::string`, and `std::array<int,65'536>`, to simulate objects of various allocation cost. The timings below are the worst-case values measured across all object types, which should be most relevant to highlight the overhead from the pointer itself (and erases flukes from the benchmarking framework). In real life scenarios, the actual measured overhead will be substantially lower, as actual business logic is likely to dominate the time budget.
 
 | Pointer                  | raw/unique | weak/shared | observer/obs_unique | observer/obs_sealed |
 |--------------------------|------------|-------------|---------------------|---------------------|
-| Create owner empty       | 1          | 0.72        | 0.83                | 1                   |
-| Create owner             | 1          | 2.58        | 1.85                | N/A                 |
-| Create owner factory     | 1          | 1.40        | 1.80                | 1.13                |
+| Create owner empty       | 1          | 1.1         | 1.1                 | 1.1                 |
+| Create owner             | 1          | 2.2         | 1.9                 | N/A                 |
+| Create owner factory     | 1          | 1.3         | 1.8                 | 1.3                 |
 | Dereference owner        | 1          | 1           | 1                   | 1                   |
-| Create observer empty    | 1          | 1           | 0.71                | 0.71                |
-| Create observer          | 1          | 2.14        | 2.14                | 2.04                |
-| Create observer copy     | 1          | 3.00        | 3.00                | 3.00                |
-| Dereference observer     | 1          | 3.50        | 0.75                | 0.75                |
+| Create observer empty    | 1          | 1.2         | 1.2                 | 1.3                 |
+| Create observer          | 1          | 1.5         | 1.6                 | 1.6                 |
+| Create observer copy     | 1          | 1.7         | 1.7                 | 1.7                 |
+| Dereference observer     | 1          | 4.8         | 1.2                 | 1.3                 |
 
 Detail of the benchmarks:
- - Create owner empty: default-construct an owner pointer (contains nullptr).
+ - Create owner empty: default-construct an owner pointer (to nullptr).
  - Create owner: construct an owner pointer by taking ownership of an object (for `oup::observer_sealed_ptr`, this is using `oup::make_observable_sealed()`).
  - Create owner factory: construct an owner pointer using `std::make_*` or `oup::make_*` factory functions.
  - Dereference owner: get a reference to the underlying owned object from an owner pointer.
- - Create observer empty: default-construct an observer pointer (contains nullptr).
+ - Create observer empty: default-construct an observer pointer (to nullptr).
  - Create observer: construct an observer pointer from an owner pointer.
  - Create observer copy: construct a new observer pointer from another observer pointer.
  - Dereference observer: get a reference to the underlying object from an observer pointer.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Labels:
  - unique: `std::unique_ptr<T>`
  - weak: `std::weak_ptr<T>`
  - shared: `std::shared_ptr<T>`
- - observer: `oup::observable_ptr<T>`
+ - observer: `oup::observer_ptr<T>`
  - obs_unique: `oup::observable_unique_ptr<T>`
  - obs_sealed: `oup::observable_sealed_ptr<T>`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# observable_unique_ptr<T, Deleter>
+# observable_unique_ptr<T, Deleter>, observable_sealed_ptr<T>, observer_ptr<T>
 
 ![Build Status](https://github.com/cschreib/observable_unique_ptr/actions/workflows/cmake.yml/badge.svg) ![Docs Build Status](https://github.com/cschreib/observable_unique_ptr/actions/workflows/doc.yml/badge.svg)
 
@@ -11,11 +11,13 @@ Built and tested on:
 
 ## Introduction
 
-This is a small header-only library, providing a unique-ownership smart pointer `observable_unique_ptr` that can be observed with non-owning pointers `observer_ptr`. It is a mixture of `std::unique_ptr` and `std::shared_ptr`: it borrows the unique-ownership semantic of `std::unique_ptr` (movable, non-copiable), but allows creating `observer_ptr` to monitor the lifetime of the pointed object (like `std::weak_ptr` for `std::shared_ptr`).
+This is a small header-only library, providing the unique-ownership smart pointers `observable_unique_ptr` and `observable_sealed_ptr` that can be observed with non-owning pointers `observer_ptr`. This is a mixture of `std::unique_ptr` and `std::shared_ptr`: it borrows the unique-ownership semantic of `std::unique_ptr` (movable, non-copiable), but allows creating `observer_ptr` to monitor the lifetime of the pointed object (like `std::weak_ptr` for `std::shared_ptr`).
 
-This is useful for cases where the shared-ownership of `std::shared_ptr` is not desirable, e.g., when lifetime must be carefully controlled and not be allowed to extend, yet non-owning/weak/observer references to the object may exist after the object has been deleted.
+The only difference between `observable_unique_ptr` and `observable_sealed_ptr` is that the former can release ownership, while the latter cannot. Disallowing release of ownership enables allocation optimizations. Therefore, the recommendation is to use `observable_sealed_ptr` unless release of ownership is required.
 
-Note: Because of the unique ownership model, observer pointers cannot extend the lifetime of the pointed object, hence `observable_unique_ptr`/`observer_ptr` provides less thread-safety compared to `std::shared_ptr`/`std::weak_ptr`. This is also true of `std::unique_ptr`, and is a fundamental limitation of unique ownership. If this is an issue, you will need either to add your own explicit locking logic, or use `std::shared_ptr`/`std::weak_ptr`.
+These pointers are useful for cases where the shared-ownership of `std::shared_ptr` is not desirable, e.g., when lifetime must be carefully controlled and not be allowed to extend, yet non-owning/weak/observer references to the object may exist after the object has been deleted.
+
+Note: Because of the unique ownership model, observer pointers cannot extend the lifetime of the pointed object, hence this library provides less thread-safety compared to `std::shared_ptr`/`std::weak_ptr`. This is also true of `std::unique_ptr`, and is a fundamental limitation of unique ownership. If this is an issue, you will need either to add your own explicit locking logic, or use `std::shared_ptr`/`std::weak_ptr`.
 
 
 ## Usage
@@ -39,7 +41,7 @@ int main() {
 
     {
         // Unique pointer that owns the object
-        auto owner_ptr = oup::make_observable_unique<std::string>("hello");
+        auto owner_ptr = oup::make_observable_sealed<std::string>("hello");
 
         // Make the observer pointer point to the object
         obs_ptr = owner_ptr;
@@ -70,10 +72,10 @@ int main() {
 
 ## Limitations
 
-The follownig limitations are features that were not implemented simply because of lack of motivation.
+The following limitations are features that were not implemented simply because of lack of motivation.
 
- - `observable_unique_ptr` does not support pointers to arrays, but `std::unique_ptr` and `std::shared_ptr` both do.
- - `observable_unique_ptr` does not support custom allocators, but `std::shared_ptr` does.
+ - this library does not support pointers to arrays, but `std::unique_ptr` and `std::shared_ptr` both do.
+ - this library does not support custom allocators, but `std::shared_ptr` does.
 
 
 ## Comparison spreadsheet
@@ -86,30 +88,34 @@ Labels:
  - weak: `std::weak_ptr<T>`
  - shared: `std::shared_ptr<T>`
  - observer: `oup::observable_ptr<T>`
- - observable_unique: `oup::observable_unique_ptr<T>`
+ - obs_unique: `oup::observable_unique_ptr<T>`
+ - obs_sealed: `oup::observable_sealed_ptr<T>`
 
-| Pointer                  | raw  | weak   | observer | unique | shared | observable_unique |
-|--------------------------|------|--------|----------|--------|--------|-------------------|
-| Owning                   | no   | no     | no       | yes    | yes    | yes               |
-| Observable deletion      | no   | yes    | yes      | yes    | yes    | yes               |
-| Thread safe deletion     | no   | yes    | no(1)    | yes(2) | yes    | yes(2)            |
-| Atomic                   | yes  | no(3)  | no       | no     | no(3)  | no                |
-| Support arrays           | yes  | yes    | no       | yes    | yes    | no                |
-| Support custom allocator | yes  | yes    | no       | yes    | yes    | no                |
-| Size in bytes (64 bit)   |      |        |          |        |        |                   |
-|  - Stack (per instance)  | 8    | 16     | 16       | 8      | 16     | 16                |
-|  - Heap (shared)         | 0    | 0      | 0        | 0      | 24     | 8                 |
-|  - Total                 | 8    | 16     | 16       | 8      | 40     | 24                |
-| Size in bytes (32 bit)   |      |        |          |        |        |                   |
-|  - Stack (per instance)  | 4    | 8      | 8        | 4      | 8      | 8                 |
-|  - Heap (shared)         | 0    | 0      | 0        | 0      | 16     | 8                 |
-|  - Total                 | 4    | 8      | 8        | 4      | 24     | 16                |
+| Pointer                  | raw  | weak   | observer | unique | shared | obs_unique | obs_sealed |
+|--------------------------|------|--------|----------|--------|--------|------------|------------|
+| Owning                   | no   | no     | no       | yes    | yes    | yes        | yes        |
+| Releasable               | N/A  | N/A    | N/A      | yes    | no     | yes        | no         |
+| Observable deletion      | no   | yes    | yes      | yes    | yes    | yes        | yes        |
+| Thread safe deletion     | no   | yes    | no(1)    | yes(2) | yes    | yes(2)     | yes(2)     |
+| Atomic                   | yes  | no(3)  | no       | no     | no(3)  | no         | no         |
+| Support arrays           | yes  | yes    | no       | yes    | yes    | no         | no         |
+| Support custom allocator | yes  | yes    | no       | yes    | yes    | no         | no         |
+| Number of heap alloc.    | 0    | 0      | 0        | 1      | 1 or 2 | 2          | 1          |
+| Size in bytes (64 bit)   |      |        |          |        |        |            |            |
+|  - Stack (per instance)  | 8    | 16     | 16       | 8      | 16     | 16         | 16         |
+|  - Heap (shared)         | 0    | 0      | 0        | 0      | 24     | 8          | 8          |
+|  - Total                 | 8    | 16     | 16       | 8      | 40     | 24         | 24         |
+| Size in bytes (32 bit)   |      |        |          |        |        |            |            |
+|  - Stack (per instance)  | 4    | 8      | 8        | 4      | 8      | 8          | 8          |
+|  - Heap (shared)         | 0    | 0      | 0        | 0      | 16     | 8          | 8          |
+|  - Total                 | 4    | 8      | 8        | 4      | 24     | 16         | 16         |
 
 Notes:
 
- - (1) If `expired()` returns true, the pointer is garanteed to remain `nullptr` forever, with no ace condition. If `expired()` returns false, the pointer could still expire on the next instant, which can lead to race conditions.
+ - (1) If `expired()` returns true, the pointer is guaranteed to remain `nullptr` forever, with no ace condition. If `expired()` returns false, the pointer could still expire on the next instant, which can lead to race conditions.
  - (2) By construction, only one thread can own the pointer, therefore deletion is thread-safe.
  - (3) Yes if using `std::atomic<std::shared_ptr<T>>` and `std::atomic<std::weak_ptr<T>>`.
+
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,12 @@ Labels:
 | Owning                   | no   | no     | no       | yes    | yes    | yes        | yes        |
 | Releasable               | N/A  | N/A    | N/A      | yes    | no     | yes        | no         |
 | Observable deletion      | no   | yes    | yes      | yes    | yes    | yes        | yes        |
-| Thread safe deletion     | no   | yes    | no(1)    | yes(2) | yes    | yes(2)     | yes(2)     |
+| Thread-safe deletion     | no   | yes    | no(1)    | yes(2) | yes    | yes(2)     | yes(2)     |
 | Atomic                   | yes  | no(3)  | no       | no     | no(3)  | no         | no         |
 | Support arrays           | yes  | yes    | no       | yes    | yes    | no         | no         |
-| Support custom allocator | yes  | yes    | no       | yes    | yes    | no         | no         |
-| Number of heap alloc.    | 0    | 0      | 0        | 1      | 1 or 2 | 2          | 1          |
+| Support custom allocator | N/A  | yes    | no       | yes    | yes    | no         | no         |
+| Support custom deleter   | N/A  | N/A    | N/A      | yes    | yes(4) | yes        | no         |
+| Number of heap alloc.    | 0    | 0      | 0        | 1      | 1/2(5) | 2          | 1          |
 | Size in bytes (64 bit)   |      |        |          |        |        |            |            |
 |  - Stack (per instance)  | 8    | 16     | 16       | 8      | 16     | 16         | 16         |
 |  - Heap (shared)         | 0    | 0      | 0        | 0      | 24     | 8          | 8          |
@@ -112,9 +113,11 @@ Labels:
 
 Notes:
 
- - (1) If `expired()` returns true, the pointer is guaranteed to remain `nullptr` forever, with no ace condition. If `expired()` returns false, the pointer could still expire on the next instant, which can lead to race conditions.
+ - (1) If `expired()` returns true, the pointer is guaranteed to remain `nullptr` forever, with no race condition. If `expired()` returns false, the pointer could still expire on the next instant, which can lead to race conditions.
  - (2) By construction, only one thread can own the pointer, therefore deletion is thread-safe.
  - (3) Yes if using `std::atomic<std::shared_ptr<T>>` and `std::atomic<std::weak_ptr<T>>`.
+ - (4) Not if using `std::make_shared()`.
+ - (5) 2 by default, or 1 if using `std::make_shared()`.
 
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -85,27 +85,31 @@ Labels:
  - unique: `std::unique_ptr<T>`
  - weak: `std::weak_ptr<T>`
  - shared: `std::shared_ptr<T>`
- - observer: `std::observable_ptr<T>`
- - observable_unique: `std::observable_unique_ptr<T>`
+ - observer: `oup::observable_ptr<T>`
+ - observable_unique: `oup::observable_unique_ptr<T>`
 
-| Pointer              | raw  | unique | weak   | shared | observer | observable_unique |
-|----------------------|------|--------|--------|--------|----------|-------------------|
-| Owning               | ✗    | ✔      | ✗      | ✔      | ✗        | ✔                 |
-| Observable deletion  | ✗    | ✔      | ✔      | ✔      | ✔        | ✔                 |
-| Thread safe deletion | ✗    | ✔(1)   | ✔      | ✔      | ✗(2)     | ✔(1)              |
-| Atomic               | ✔    | ✗      | ✗(3)   | ✗(3)   | ✗        | ✗                 |
-| Stack bytes (64bit)  | 8    | 8      | 16     | 16     | 16       | 16                |
-| Heap bytes (64bit)   | 0    | 0      | 0      | 24     | 0        | 8                 |
-| Total bytes (64bit)  | 8    | 8      | 16     | 40     | 16       | 24                |
-| Stack bytes (32bit)  | 4    | 4      | 8      | 8      | 8        | 8                 |
-| Heap bytes (32bit)   | 0    | 0      | 0      | 16     | 0        | 8                 |
-| Total bytes (32bit)  | 4    | 4      | 8      | 24     | 8        | 16                |
+| Pointer                  | raw  | unique | weak   | shared | observer | observable_unique |
+|--------------------------|------|--------|--------|--------|----------|-------------------|
+| Owning                   | ❌    | ✔      | ❌      | ✔      | ❌        | ✔                 |
+| Observable deletion      | ❌    | ✔      | ✔      | ✔      | ✔        | ✔                 |
+| Thread safe deletion     | ❌    | ✔(1)   | ✔      | ✔      | ❌(2)     | ✔(1)              |
+| Atomic                   | ✔    | ❌      | ❌(3)   | ❌(3)   | ❌        | ❌                 |
+| Support arrays           | ✔    | ✔      | ✔      | ✔      | ❌        | ❌                 |
+| Support custom allocator | ✔    | ✔      | ✔      | ✔      | ❌        | ❌                 |
+| Size in bytes (64 bit)   |      |        |        |        |          |                   |
+|  - Stack (per instance)  | 8    | 8      | 16     | 16     | 16       | 16                |
+|  - Heap (shared)         | 0    | 0      | 0      | 24     | 0        | 8                 |
+|  - Total                 | 8    | 8      | 16     | 40     | 16       | 24                |
+| Size in bytes (32 bit)   |      |        |        |        |          |                   |
+|  - Stack (per instance)  | 4    | 4      | 8      | 8      | 8        | 8                 |
+|  - Heap (shared)         | 0    | 0      | 0      | 16     | 0        | 8                 |
+|  - Total                 | 4    | 4      | 8      | 24     | 8        | 16                |
 
 Notes:
 
  - (1) By construction, only one thread can own the pointer, therefore deletion is thread-safe.
  - (2) If `expired()` returns true, the pointer is garanteed to remain `nullptr` forever, with no race condition. If `expired()` returns false, the pointer could still expire on the next instant, which can lead to race conditions.
- - (3) Yes, if using `std::atomic<std::shared_ptr<T>>`.
+ - (3) Yes if using `std::atomic<std::shared_ptr<T>>` and `std::atomic<std::weak_ptr<T>>`.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Note: Because of the unique ownership model, observer pointers cannot extend the
 ## Usage
 
 This is a header-only library requiring a C++17-compliant compiler. You have multiple ways to set it up:
- - just include this repository as a submodule in your own git repository and use CMake `add_subdirectory`,
- - use CMake `FetchContent`,
+ - just include this repository as a submodule in your own git repository and use CMake `add_subdirectory` (or use CMake `FetchContent`), then link with `target_link_libraries(<your-target> PUBLIC oup::oup)`.
  - download the header and include it in your own sources.
 
 From there, include the single header `<oup/observable_unique_ptr.hpp>`, and directly use the smart pointer in your own code:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The following limitations are features that were not implemented simply because 
 
 ## Comparison spreadsheet
 
-In this comparison spreadsheet, the raw pointer `T*` is assumed to never be owning, and used only to observe an existing object (which may or may not have been deleted). The stack and heap sizes were measured with gcc and libstdc++.
+In this comparison spreadsheet, the raw pointer `T*` is assumed to never be owning, and used only to observe an existing object (which may or may not have been deleted). The stack and heap sizes were measured with gcc 9.3.0 and libstdc++.
 
 Labels:
  - raw: `T*`
@@ -118,6 +118,34 @@ Notes:
  - (3) Yes if using `std::atomic<std::shared_ptr<T>>` and `std::atomic<std::weak_ptr<T>>`.
  - (4) Not if using `std::make_shared()`.
  - (5) 2 by default, or 1 if using `std::make_shared()`.
+
+
+## Speed benchmarks
+
+Labels are the same as in the comparison spreadsheet. The speed benchmarks were compiled with gcc 9.3.0 and libstdc++, with all optimizations turned on (except LTO), and run on a linux (5.1.0-89) machine with a Ryzen 5 2600 CPU. Speed is measured relative to `std::unique_ptr<T>` used as owner pointer, and `T*` used as observer pointer.
+
+You can run the benchmarks yourself, they are located in `tests/speed_benchmark.cpp`. The benchmark executable runs tests for three object types: `int`, `std::string`, and `std::array<int,65'536>`, to simulate objects of various allocation cost. The timings below are reported for `int`, which should be most relevant to highlight the overhead from the pointer itself. In real life scenarios, the actual measured overhead will be substantially lower, as actual business logic is likely to dominate the time budget.
+
+| Pointer                  | raw/unique | weak/shared | observer/obs_unique | observer/obs_sealed |
+|--------------------------|------------|-------------|---------------------|---------------------|
+| Create owner empty       | 1          | 0.72        | 0.83                | 1                   |
+| Create owner             | 1          | 2.58        | 1.85                | N/A                 |
+| Create owner factory     | 1          | 1.40        | 1.80                | 1.13                |
+| Dereference owner        | 1          | 1           | 1                   | 1                   |
+| Create observer empty    | 1          | 1           | 0.71                | 0.71                |
+| Create observer          | 1          | 2.14        | 2.14                | 2.04                |
+| Create observer copy     | 1          | 3.00        | 3.00                | 3.00                |
+| Dereference observer     | 1          | 3.50        | 0.75                | 0.75                |
+
+Detail of the benchmarks:
+ - Create owner empty: default-construct an owner pointer (contains nullptr).
+ - Create owner: construct an owner pointer by taking ownership of an object (for `oup::observer_sealed_ptr`, this is using `oup::make_observable_sealed()`).
+ - Create owner factory: construct an owner pointer using `std::make_*` or `oup::make_*` factory functions.
+ - Dereference owner: get a reference to the underlying owned object from an owner pointer.
+ - Create observer empty: default-construct an observer pointer (contains nullptr).
+ - Create observer: construct an observer pointer from an owner pointer.
+ - Create observer copy: construct a new observer pointer from another observer pointer.
+ - Dereference observer: get a reference to the underlying object from an observer pointer.
 
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -88,27 +88,27 @@ Labels:
  - observer: `oup::observable_ptr<T>`
  - observable_unique: `oup::observable_unique_ptr<T>`
 
-| Pointer                  | raw  | unique | weak   | shared | observer | observable_unique |
-|--------------------------|------|--------|--------|--------|----------|-------------------|
-| Owning                   | ❌    | ✔      | ❌      | ✔      | ❌        | ✔                 |
-| Observable deletion      | ❌    | ✔      | ✔      | ✔      | ✔        | ✔                 |
-| Thread safe deletion     | ❌    | ✔(1)   | ✔      | ✔      | ❌(2)     | ✔(1)              |
-| Atomic                   | ✔    | ❌      | ❌(3)   | ❌(3)   | ❌        | ❌                 |
-| Support arrays           | ✔    | ✔      | ✔      | ✔      | ❌        | ❌                 |
-| Support custom allocator | ✔    | ✔      | ✔      | ✔      | ❌        | ❌                 |
-| Size in bytes (64 bit)   |      |        |        |        |          |                   |
-|  - Stack (per instance)  | 8    | 8      | 16     | 16     | 16       | 16                |
-|  - Heap (shared)         | 0    | 0      | 0      | 24     | 0        | 8                 |
-|  - Total                 | 8    | 8      | 16     | 40     | 16       | 24                |
-| Size in bytes (32 bit)   |      |        |        |        |          |                   |
-|  - Stack (per instance)  | 4    | 4      | 8      | 8      | 8        | 8                 |
-|  - Heap (shared)         | 0    | 0      | 0      | 16     | 0        | 8                 |
-|  - Total                 | 4    | 4      | 8      | 24     | 8        | 16                |
+| Pointer                  | raw  | weak   | observer | unique | shared | observable_unique |
+|--------------------------|------|--------|----------|--------|--------|-------------------|
+| Owning                   | no   | no     | no       | yes    | yes    | yes               |
+| Observable deletion      | no   | yes    | yes      | yes    | yes    | yes               |
+| Thread safe deletion     | no   | yes    | no(1)    | yes(2) | yes    | yes(2)            |
+| Atomic                   | yes  | no(3)  | no       | no     | no(3)  | no                |
+| Support arrays           | yes  | yes    | no       | yes    | yes    | no                |
+| Support custom allocator | yes  | yes    | no       | yes    | yes    | no                |
+| Size in bytes (64 bit)   |      |        |          |        |        |                   |
+|  - Stack (per instance)  | 8    | 16     | 16       | 8      | 16     | 16                |
+|  - Heap (shared)         | 0    | 0      | 0        | 0      | 24     | 8                 |
+|  - Total                 | 8    | 16     | 16       | 8      | 40     | 24                |
+| Size in bytes (32 bit)   |      |        |          |        |        |                   |
+|  - Stack (per instance)  | 4    | 8      | 8        | 4      | 8      | 8                 |
+|  - Heap (shared)         | 0    | 0      | 0        | 0      | 16     | 8                 |
+|  - Total                 | 4    | 8      | 8        | 4      | 24     | 16                |
 
 Notes:
 
- - (1) By construction, only one thread can own the pointer, therefore deletion is thread-safe.
- - (2) If `expired()` returns true, the pointer is garanteed to remain `nullptr` forever, with no race condition. If `expired()` returns false, the pointer could still expire on the next instant, which can lead to race conditions.
+ - (1) If `expired()` returns true, the pointer is garanteed to remain `nullptr` forever, with no ace condition. If `expired()` returns false, the pointer could still expire on the next instant, which can lead to race conditions.
+ - (2) By construction, only one thread can own the pointer, therefore deletion is thread-safe.
  - (3) Yes if using `std::atomic<std::shared_ptr<T>>` and `std::atomic<std::weak_ptr<T>>`.
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # observable_unique_ptr<T, Deleter>
 
-![Build Status](https://github.com/cschreib/observable_unique_ptr/actions/workflows/cmake.yml/badge.svg) ![Build Status](https://github.com/cschreib/observable_unique_ptr/actions/workflows/doc.yml/badge.svg)
+![Build Status](https://github.com/cschreib/observable_unique_ptr/actions/workflows/cmake.yml/badge.svg) ![Docs Build Status](https://github.com/cschreib/observable_unique_ptr/actions/workflows/doc.yml/badge.svg)
+
+Built and tested on:
+ - Linux (GCC/clang)
+ - Windows (MSVC 32/64)
+ - MacOS (clang)
+ - WebAssembly (Emscripten)
+
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -76,15 +76,8 @@ The follownig limitations are features that were not implemented simply because 
  - `observable_unique_ptr` does not support pointers to arrays, but `std::unique_ptr` and `std::shared_ptr` both do.
  - `observable_unique_ptr` does not support custom allocators, but `std::shared_ptr` does.
 
-
 ## Notes
-
 
 ### Alternative implementation
 
 An alternative implementation of an "observable unique pointer" can be found [here](https://www.codeproject.com/articles/1011134/smart-observers-to-use-with-unique-ptr). It does not compile out of the box with gcc unfortunately, but it does contain more features (like creating an observer pointer from a raw `this`) and lacks others (their `make_observable` always performs two allocations). Have a look to check if this better suits your needs.
-
-
-### ABI compatibility
-
-When compiled in C++20 mode, by default the implementation will attempt to optimize empty deleters. This is not ABI-compatible with previous versions of C++, which lack the `[[no_unique_address]]` attribute (introduced in C++20). If ABI compatibility with previous versions of C++ is a concern to you, please define the macro `OUP_CPP17_ABI_COMPAT` before including the header of this library. This will disable the empty deleter optimisation, and enable binary compatibility with older C++ versions.

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -540,9 +540,19 @@ public:
     }
 
     /// Create a weak pointer from an owning pointer.
-    template<typename U, typename enable = std::enable_if_t<std::is_convertible_v<U*, T*>>>
-    observer_ptr(const observable_unique_ptr<U>& owner) noexcept :
+    template<typename U, typename D, typename enable = std::enable_if_t<std::is_convertible_v<U*, T*>>>
+    observer_ptr(const observable_unique_ptr<U,D>& owner) noexcept :
         block(owner.block), data(owner.ptr_deleter.data) {
+        if (block) {
+            ++block->refcount;
+        }
+    }
+
+    /// Copy an existing observer_ptr instance
+    /** \param value The existing weak pointer to copy
+    */
+    observer_ptr(const observer_ptr& value) noexcept :
+        block(value.block), data(value.data) {
         if (block) {
             ++block->refcount;
         }
@@ -587,8 +597,8 @@ public:
     *   \note This operator only takes part in  overload resolution if D
     *         is convertible to Deleter and U* is convertible to T*.
     */
-    template<typename U, typename enable = std::enable_if_t<std::is_convertible_v<U*, T*>>>
-    observer_ptr& operator=(const observable_unique_ptr<U>& owner) noexcept {
+    template<typename U, typename D, typename enable = std::enable_if_t<std::is_convertible_v<U*, T*>>>
+    observer_ptr& operator=(const observable_unique_ptr<U,D>& owner) noexcept {
         if (data) {
             pop_ref_();
         }

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -194,7 +194,7 @@ public:
     *         using make_observable_unique() instead of this constructor.
     */
     explicit observable_unique_ptr(T* value) :
-        observable_unique_ptr(allocate_block_(), value) {}
+        observable_unique_ptr(value != nullptr ? allocate_block_() : nullptr, value) {}
 
     /// Explicit ownership capture of a raw pointer, with customer deleter.
     /** \param value The raw pointer to take ownership of
@@ -204,7 +204,7 @@ public:
     *         using make_observable_unique() instead of this constructor.
     */
     explicit observable_unique_ptr(T* value, Deleter del) :
-        observable_unique_ptr(allocate_block_(), value, std::move(del)) {}
+        observable_unique_ptr(value != nullptr ? allocate_block_() : nullptr, value, std::move(del)) {}
 
     /// Transfer ownership by implicit casting
     /** \param value The pointer to take ownership from

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -908,7 +908,7 @@ public:
 
     /// Move from an existing observer_ptr instance
     /** \param value The existing weak pointer to move from
-    *   \note After this observable_unique_ptr is created, the source
+    *   \note After this observer_ptr is created, the source
     *         pointer is set to null.
     */
     observer_ptr(observer_ptr&& value) noexcept : block(value.block), data(value.data) {
@@ -918,7 +918,7 @@ public:
 
     /// Move from an existing observer_ptr instance
     /** \param value The existing weak pointer to move from
-    *   \note After this observable_unique_ptr is created, the source
+    *   \note After this observer_ptr is created, the source
     *         pointer is set to null. This constructor only takes part in
     *         overload resolution if D is convertible to Deleter and U* is
     *         convertible to T*.
@@ -1057,7 +1057,7 @@ public:
     /// Get a non-owning raw pointer to the pointed object, or nullptr if deleted.
     /** \return 'nullptr' if expired() is 'true', or the pointed object otherwise
     *   \note This does not extend the lifetime of the pointed object. Therefore, when
-    *         calling this function, you must make sure that the owning observable_unique_ptr
+    *         calling this function, you must make sure that the owning pointer
     *         will not be reset until you are done using the raw pointer.
     */
     T* get() const noexcept {
@@ -1067,7 +1067,7 @@ public:
     /// Get a non-owning raw pointer to the pointed object, possibly dangling.
     /** \return The pointed object, which may be a dangling pointer if the object has been deleted
     *   \note This does not extend the lifetime of the pointed object. Therefore, when
-    *         calling this function, you must make sure that the owning observable_unique_ptr
+    *         calling this function, you must make sure that the owning pointer
     *         will not be reset until you are done using the raw pointer. In addition,
     *         this function will not check if the pointer has expired (i.e., if the object
     *         has been deleted), so the returned pointer may be dangling.
@@ -1089,7 +1089,7 @@ public:
     /** \return 'nullptr' if expired() is 'true', or the pointed object otherwise
     *   \note Contrary to std::weak_ptr::lock(), this does not extend the lifetime
     *         of the pointed object. Therefore, when calling this function, you must
-    *         make sure that the owning observable_unique_ptr will not be reset until
+    *         make sure that the owning pointer will not be reset until
     *         you are done using the raw pointer.
     */
     T* operator->() const noexcept {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,7 +66,10 @@ run_compile_test("is_copy_assignment_allowed" compile_test_copy_assign.cpp FALSE
 run_compile_test("is_implicit_constructor_base_to_derived_allowed_acquire" compile_test_implicit_const_base_to_derived1.cpp FALSE)
 run_compile_test("is_implicit_constructor_base_to_derived_allowed_move" compile_test_implicit_const_base_to_derived2.cpp FALSE)
 run_compile_test("is_implicit_constructor_base_to_derived_allowed_move_with_deleter" compile_test_implicit_const_base_to_derived3.cpp FALSE)
+run_compile_test("is_observer_construct_raw_allowed" compile_test_observer_construct_raw.cpp FALSE)
 run_compile_test("is_observer_assign_raw_allowed" compile_test_observer_assign_raw.cpp FALSE)
+run_compile_test("is_acquire_construct_raw_allowed" compile_test_sealed_construct_raw.cpp FALSE)
+run_compile_test("is_acquire_assign_raw_allowed" compile_test_sealed_assign_raw.cpp FALSE)
 
 message(STATUS "Running compile-time tests ended.")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,5 +80,6 @@ target_link_libraries(oup_size_benchmark PRIVATE oup::oup)
 
 add_executable(oup_speed_benchmark
   ${PROJECT_SOURCE_DIR}/tests/speed_benchmark.cpp
-  ${PROJECT_SOURCE_DIR}/tests/speed_benchmark_utility.cpp)
+  ${PROJECT_SOURCE_DIR}/tests/speed_benchmark_utility.cpp
+  ${PROJECT_SOURCE_DIR}/tests/speed_benchmark_utility2.cpp)
 target_link_libraries(oup_speed_benchmark PRIVATE oup::oup)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,3 +77,8 @@ message(STATUS "Running compile-time tests ended.")
 
 add_executable(oup_size_benchmark ${PROJECT_SOURCE_DIR}/tests/size_benchmark.cpp)
 target_link_libraries(oup_size_benchmark PRIVATE oup::oup)
+
+add_executable(oup_speed_benchmark
+  ${PROJECT_SOURCE_DIR}/tests/speed_benchmark.cpp
+  ${PROJECT_SOURCE_DIR}/tests/speed_benchmark_utility.cpp)
+target_link_libraries(oup_speed_benchmark PRIVATE oup::oup)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(oup_tests PRIVATE oup::oup)
 
 include(CTest)
 include(Catch)
+
 catch_discover_tests(oup_tests)
 
 # Compile-time error tests
@@ -30,7 +31,7 @@ function(run_compile_test TEST_NAME TEST_FILE EXPECTED)
       "-DINCLUDE_DIRECTORIES=${PROJECT_SOURCE_DIR}/include"
       "-DCMAKE_CXX_STANDARD=17")
 
-  if (COMPILE_TEST_RESULT STREQUAL EXPECTED)
+  if(COMPILE_TEST_RESULT STREQUAL EXPECTED)
     message(STATUS "Test ${TEST_NAME} passed.")
   else()
     message(WARNING "FAILED test: ${TEST_NAME}, expected ${EXPECTED} and got ${COMPILE_TEST_RESULT}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v3.0.0-preview3
+  GIT_TAG        912df7df354fd6c814b5d7c45ac44f494a5fb5fe
 )
 
 FetchContent_MakeAvailable(Catch2)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,18 @@
+# set OS preprocessor defines
+if(CMAKE_SYSTEM_NAME MATCHES "Emscripten")
+    set(OUP_PLATFORM_WASM TRUE)
+    set(OUP_COMPILER_EMSCRIPTEN TRUE)
+elseif (APPLE)
+    set(OUP_PLATFORM_OSX TRUE)
+elseif (UNIX)
+    set(OUP_PLATFORM_LINUX TRUE)
+elseif (WIN32)
+    set(OUP_PLATFORM_WINDOWS TRUE)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        set(OUP_COMPILER_MSVC TRUE)
+    endif()
+endif()
+
 include(FetchContent)
 
 FetchContent_Declare(
@@ -13,6 +28,13 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${Catch2_SOURCE_DIR}/extras")
 add_executable(oup_tests ${PROJECT_SOURCE_DIR}/tests/runtime_tests.cpp)
 target_link_libraries(oup_tests PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(oup_tests PRIVATE oup::oup)
+target_compile_definitions(oup_tests PRIVATE
+  OUP_PLATFORM_OSX
+  OUP_PLATFORM_WASM
+  OUP_PLATFORM_LINUX
+  OUP_PLATFORM_WINDOWS
+  OUP_COMPILER_MSVC
+  OUP_COMPILER_EMSCRIPTEN)
 
 include(CTest)
 include(Catch)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,3 +46,8 @@ run_compile_test("is_implicit_constructor_base_to_derived_allowed_move" compile_
 run_compile_test("is_implicit_constructor_base_to_derived_allowed_move_with_deleter" compile_test_implicit_const_base_to_derived3.cpp FALSE)
 
 message(STATUS "Running compile-time tests ended.")
+
+# Benchmarks
+
+add_executable(oup_size_benchmark ${PROJECT_SOURCE_DIR}/tests/size_benchmark.cpp)
+target_link_libraries(oup_size_benchmark PRIVATE oup::oup)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ run_compile_test("is_copy_assignment_allowed" compile_test_copy_assign.cpp FALSE
 run_compile_test("is_implicit_constructor_base_to_derived_allowed_acquire" compile_test_implicit_const_base_to_derived1.cpp FALSE)
 run_compile_test("is_implicit_constructor_base_to_derived_allowed_move" compile_test_implicit_const_base_to_derived2.cpp FALSE)
 run_compile_test("is_implicit_constructor_base_to_derived_allowed_move_with_deleter" compile_test_implicit_const_base_to_derived3.cpp FALSE)
+run_compile_test("is_observer_assign_raw_allowed" compile_test_observer_assign_raw.cpp FALSE)
 
 message(STATUS "Running compile-time tests ended.")
 

--- a/tests/compile_test_observer_assign_raw.cpp
+++ b/tests/compile_test_observer_assign_raw.cpp
@@ -1,0 +1,6 @@
+#include "tests_common.hpp"
+
+int main() {
+    test_optr ptr(new test_object);
+    return 0;
+}

--- a/tests/compile_test_observer_construct_raw.cpp
+++ b/tests/compile_test_observer_construct_raw.cpp
@@ -1,7 +1,6 @@
 #include "tests_common.hpp"
 
 int main() {
-    test_optr ptr;
-    ptr = new test_object;
+    test_optr ptr(new test_object);
     return 0;
 }

--- a/tests/compile_test_sealed_assign_raw.cpp
+++ b/tests/compile_test_sealed_assign_raw.cpp
@@ -1,7 +1,7 @@
 #include "tests_common.hpp"
 
 int main() {
-    test_optr ptr;
+    test_sptr ptr;
     ptr = new test_object;
     return 0;
 }

--- a/tests/compile_test_sealed_construct_raw.cpp
+++ b/tests/compile_test_sealed_construct_raw.cpp
@@ -1,7 +1,6 @@
 #include "tests_common.hpp"
 
 int main() {
-    test_optr ptr;
-    ptr = new test_object;
+    test_sptr ptr(new test_object);
     return 0;
 }

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -70,6 +70,10 @@ struct memory_tracker {
     std::size_t double_del() const { return double_delete - initial_double_delete; }
 };
 
+TEST_CASE("owner size", "[owner_size]") {
+    REQUIRE(sizeof(test_ptr) == 2*sizeof(void*));
+}
+
 TEST_CASE("owner default constructor", "[owner_construction]") {
     memory_tracker mem_track;
 
@@ -936,6 +940,10 @@ TEST_CASE("make observable throw in constructor", "[make_observable_unique]") {
     REQUIRE(instances_thrower == 0);
     REQUIRE(mem_track.leaks() == 0u);
     REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer size", "[observer_size]") {
+    REQUIRE(sizeof(test_optr) == 2*sizeof(void*));
 }
 
 TEST_CASE("observer default constructor", "[observer_construction]") {

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -237,6 +237,37 @@ TEST_CASE("owner acquiring constructor with deleter", "[owner_construction]") {
     REQUIRE(mem_track.double_del() == 0u);
 }
 
+TEST_CASE("owner acquiring constructor null", "[owner_construction]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr ptr{static_cast<test_object*>(nullptr)};
+        REQUIRE(instances == 0);
+        REQUIRE(ptr.get() == nullptr);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("owner acquiring constructor null with deleter", "[owner_construction]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr_with_deleter ptr{static_cast<test_object*>(nullptr), test_deleter{42}};
+        REQUIRE(instances == 0);
+        REQUIRE(instances_deleter == 1);
+        REQUIRE(ptr.get() == nullptr);
+        REQUIRE(ptr.get_deleter().state_ == 42);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(instances_deleter == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
 TEST_CASE("owner implicit conversion constructor", "[owner_construction]") {
     memory_tracker mem_track;
 

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -900,7 +900,7 @@ TEST_CASE("owner release valid from make_observable_unique", "[owner_utility]") 
     REQUIRE(mem_track.double_del() == 0u);
 }
 
-TEST_CASE("owner release valid from make_observable_unique with obsever", "[owner_utility]") {
+TEST_CASE("owner release valid from make_observable_unique with observer", "[owner_utility]") {
     memory_tracker mem_track;
 
     {

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -15,6 +15,8 @@ bool memory_tracking = false;
 // Getting weird errors on MacOS when overriding operator new and delete,
 // so disable the memory leak checking for this platform.
 #   define CHECK_MEMORY_LEAKS 0
+#else
+#   define CHECK_MEMORY_LEAKS 1
 #endif
 
 #if defined(CHECK_MEMORY_LEAKS) && CHECK_MEMORY_LEAKS

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -10,10 +10,14 @@ std::size_t num_allocations = 0u;
 std::size_t double_delete = 0u;
 bool memory_tracking = false;
 
-// NB: getting weird errors on MacOS when doing this
-#if !defined(__APPLE__)
-void* operator new(size_t size)
-{
+#if defined(OUP_PLATFORM_OSX)
+// Getting weird errors on MacOS when overriding operator new and delete,
+// so disable the memory leak checking for this platform.
+#   define CHECK_MEMORY_LEAKS 0
+#endif
+
+#if defined(CHECK_MEMORY_LEAKS) && CHECK_MEMORY_LEAKS
+void* allocate(std::size_t size, bool array) {
     if (memory_tracking && num_allocations == max_allocations) {
         throw std::bad_alloc();
     }

--- a/tests/size_benchmark.cpp
+++ b/tests/size_benchmark.cpp
@@ -1,0 +1,126 @@
+#include <memory>
+#include <iostream>
+#include <oup/observable_unique_ptr.hpp>
+
+// Allocation tracker, to catch memory leaks and double delete
+constexpr std::size_t max_allocations = 20'000;
+void* allocations[max_allocations];
+std::size_t allocations_bytes[max_allocations];
+std::size_t num_allocations = 0u;
+std::size_t size_allocations = 0u;
+std::size_t double_delete = 0u;
+bool memory_tracking = false;
+
+// NB: getting weird errors on MacOS when doing this
+#if !defined(__APPLE__)
+void* operator new(size_t size)
+{
+    if (memory_tracking && num_allocations == max_allocations) {
+        throw std::bad_alloc();
+    }
+
+    void* p = std::malloc(size);
+    if (!p) {
+        throw std::bad_alloc();
+    }
+
+    if (memory_tracking) {
+        allocations[num_allocations] = p;
+        allocations_bytes[num_allocations] = size;
+        ++num_allocations;
+        size_allocations += size;
+    }
+
+    return p;
+}
+
+void operator delete(void* p) noexcept
+{
+    if (memory_tracking) {
+        bool found = false;
+        for (std::size_t i = 0; i < num_allocations; ++i) {
+            if (allocations[i] == p) {
+                std::swap(allocations[i], allocations[num_allocations-1]);
+                std::swap(allocations_bytes[i], allocations_bytes[num_allocations-1]);
+                --num_allocations;
+                size_allocations -= allocations_bytes[num_allocations-1];
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            ++double_delete;
+        }
+    }
+
+    std::free(p);
+}
+#endif
+
+struct memory_tracker {
+    std::size_t initial_allocations;
+    std::size_t initial_double_delete;
+
+    memory_tracker() noexcept :
+        initial_allocations(num_allocations), initial_double_delete(double_delete) {
+        memory_tracking = true;
+    }
+
+    ~memory_tracker() noexcept {
+        memory_tracking = false;
+    }
+
+    std::size_t leaks() const { return num_allocations - initial_allocations; }
+    std::size_t double_del() const { return double_delete - initial_double_delete; }
+};
+
+int main() {
+    memory_tracking = true;
+    std::size_t init_alloc = 0u;
+
+    std::size_t unique_size = 0u;
+    init_alloc = size_allocations;
+    {
+        std::unique_ptr<int> ptr(new int);
+        unique_size = size_allocations - sizeof(int) - init_alloc;
+        std::cout << "unique_ptr size: " << sizeof(ptr) << ", " << unique_size << std::endl;
+    }
+
+    init_alloc = size_allocations;
+    {
+        std::unique_ptr<int> ptr(new int);
+        int* wptr = ptr.get();
+        std::cout << "raw pointer size: " << sizeof(wptr) << ", " << size_allocations - sizeof(int) - init_alloc - unique_size << std::endl;
+    }
+
+    std::size_t shared_size = 0u;
+    init_alloc = size_allocations;
+    {
+        std::shared_ptr<int> ptr(new int);
+        shared_size = size_allocations - sizeof(int) - init_alloc;
+        std::cout << "shared_ptr size: " << sizeof(ptr) << ", " << shared_size << std::endl;
+    }
+
+    init_alloc = size_allocations;
+    {
+        std::shared_ptr<int> ptr(new int);
+        std::weak_ptr<int> wptr(ptr);
+        std::cout << "weak_ptr size: " <<  sizeof(wptr) << ", " << size_allocations - sizeof(int) - init_alloc - shared_size << std::endl;
+    }
+
+    std::size_t observable_size = 0u;
+    init_alloc = size_allocations;
+    {
+        oup::observable_unique_ptr<int> ptr(new int);
+        observable_size = size_allocations - sizeof(int) - init_alloc;
+        std::cout << "observable_unique_ptr size: " << sizeof(ptr) << ", " << observable_size << std::endl;
+    }
+
+    init_alloc = size_allocations;
+    {
+        oup::observable_unique_ptr<int> ptr(new int);
+        oup::observer_ptr<int> wptr(ptr);
+        std::cout << "observer_ptr size: " << sizeof(wptr) << ", " << size_allocations - sizeof(int) - init_alloc - observable_size << std::endl;
+    }
+}

--- a/tests/speed_benchmark.cpp
+++ b/tests/speed_benchmark.cpp
@@ -1,150 +1,49 @@
-#include <memory>
-#include <iostream>
-#include <chrono>
-#include <array>
-#include <string>
-#include <oup/observable_unique_ptr.hpp>
-
-// External functions, the compiler cannot see through. Prevents optimisations.
-template<typename T>
-void use_object(T&) noexcept;
-
-template<typename T>
-struct pointer_traits;
-
-template<typename T>
-struct pointer_traits<std::unique_ptr<T>> {
-    using element_type = T;
-    using ptr_type = std::unique_ptr<T>;
-    using weak_type = T*;
-
-    static ptr_type make_ptr() noexcept { return ptr_type(new element_type); }
-    static ptr_type make_ptr_factory() noexcept { return std::make_unique<element_type>(); }
-    static weak_type make_weak(ptr_type& p) noexcept { return p.get(); }
-    template<typename F>
-    static void deref_weak(weak_type& p, F&& func) noexcept { return func(*p); }
-};
-
-template<typename T>
-struct pointer_traits<std::shared_ptr<T>> {
-    using element_type = T;
-    using ptr_type = std::shared_ptr<T>;
-    using weak_type = std::weak_ptr<T>;
-
-    static ptr_type make_ptr() noexcept { return ptr_type(new element_type); }
-    static ptr_type make_ptr_factory() noexcept { return std::make_shared<element_type>(); }
-    static weak_type make_weak(ptr_type& p) noexcept { return weak_type(p); }
-    template<typename F>
-    static void deref_weak(weak_type& p, F&& func) noexcept { if (auto s = p.lock()) func(*s); }
-};
-
-template<typename T>
-struct pointer_traits<oup::observable_unique_ptr<T>> {
-    using element_type = T;
-    using ptr_type = oup::observable_unique_ptr<T>;
-    using weak_type = oup::observer_ptr<T>;
-
-    static ptr_type make_ptr() noexcept { return ptr_type(new element_type); }
-    static ptr_type make_ptr_factory() noexcept { return oup::make_observable_unique<element_type>(); }
-    static weak_type make_weak(ptr_type& p) noexcept { return weak_type(p); }
-    template<typename F>
-    static void deref_weak(weak_type& p, F&& func) noexcept { return func(*p); }
-};
-
-template<typename T>
-struct pointer_traits<oup::observable_sealed_ptr<T>> {
-    using element_type = T;
-    using ptr_type = oup::observable_sealed_ptr<T>;
-    using weak_type = oup::observer_ptr<T>;
-
-    static ptr_type make_ptr() noexcept { return oup::make_observable_sealed<element_type>(); }
-    static ptr_type make_ptr_factory() noexcept { return oup::make_observable_sealed<element_type>(); }
-    static weak_type make_weak(ptr_type& p) noexcept { return weak_type(p); }
-    template<typename F>
-    static void deref_weak(weak_type& p, F&& func) noexcept { return func(*p); }
-};
-
-template<typename T>
-struct benchmark {
-    using traits = pointer_traits<T>;
-    using element_type = typename traits::element_type;
-    using owner_type = typename traits::ptr_type;
-    using weak_type = typename traits::weak_type;
-
-    owner_type owner;
-    weak_type weak;
-
-    benchmark() : owner(traits::make_ptr()), weak(traits::make_weak(owner)) {}
-
-    void construct_destruct_owner_empty() {
-        auto p = owner_type{};
-        use_object(p);
-    }
-
-    void construct_destruct_owner() {
-        auto p = traits::make_ptr();
-        use_object(p);
-    }
-
-    void construct_destruct_owner_factory() {
-        auto p = traits::make_ptr_factory();
-        use_object(p);
-    }
-
-    void construct_destruct_weak_empty() {
-        auto p = weak_type{};
-        use_object(p);
-    }
-
-    void construct_destruct_weak() {
-        auto wp = traits::make_weak(owner);
-        use_object(wp);
-    }
-
-    void dereference_owner() {
-        use_object(*owner);
-    }
-
-    void dereference_weak() {
-        traits::deref_weak(weak, [](auto& o) { use_object(o); });
-    }
-    void construct_destruct_weak_copy() {
-        auto wp = weak;
-        use_object(wp);
-    }
-};
-
-using timer = std::chrono::high_resolution_clock;
+#include "speed_benchmark_common.hpp"
+#include <cmath>
 
 template<typename B, typename F>
-double run_benchmark_for(F&& func) {
+auto run_benchmark_for(F&& func) {
     B bench{};
 
-    auto prev = timer::now();
     double elapsed = 0.0;
+    double elapsed_square = 0.0;
     double count = 0.0;
-    constexpr std::size_t num_iter = 10'000;
+    double attempts = 0.0;
+    constexpr std::size_t num_iter = 1'000'000;
 
-    while (elapsed < 1.0) {
+    while (elapsed*num_iter < 1.0) {
+        auto prev = timer::now();
+
         for (std::size_t i = 0; i < num_iter; ++i) {
             func(bench);
         }
 
         auto now = timer::now();
-        elapsed += std::chrono::duration_cast<std::chrono::duration<double>>(now - prev).count();
-        count += static_cast<double>(num_iter);
-        std::swap(now, prev);
+
+        double spent = std::chrono::duration_cast<std::chrono::duration<double>>(now - prev).count()/num_iter;
+        elapsed += spent;
+        elapsed_square += spent*spent;
+        attempts += 1.0;
     }
 
-    return elapsed/count;
+    double stddev = std::sqrt(elapsed_square/attempts - (elapsed/attempts)*(elapsed/attempts))/std::sqrt(attempts);
+
+    return std::make_pair(elapsed/attempts, stddev);
 }
 
 template<typename B, typename F>
 auto run_benchmark(F&& func) {
     using ref_type = benchmark<std::unique_ptr<typename B::element_type>>;
-    double result = run_benchmark_for<B>(func);
-    double result_ref = run_benchmark_for<ref_type>(func);
-    return std::make_pair(result, result/result_ref);
+
+    auto result = run_benchmark_for<B>(func);
+    auto result_ref = run_benchmark_for<ref_type>(func);
+
+    double ratio = result.first/result_ref.first;
+    double rel_err = result.second/result.first;
+    double rel_err_ref = result_ref.second/result_ref.first;
+    double ratio_stddev = std::sqrt(rel_err*rel_err + rel_err_ref*rel_err_ref)*ratio;
+
+    return std::make_pair(result, std::make_pair(ratio, ratio_stddev));
 }
 
 template<typename T>
@@ -161,7 +60,9 @@ void do_benchmarks_for_ptr(const char* type_name, const char* ptr_name) {
     auto dereference_weak = run_benchmark<B>([](auto& b) { return b.dereference_weak(); });
 
     std::cout << ptr_name << "<" << type_name << ">:" << std::endl;
-    #define report(which) std::cout << " - " << #which << ": " << which.first*1e6 << "us (x" << which.second << ")" << std::endl
+    #define report(which) std::cout << " - " << #which << ": " << \
+        which.first.first*1e6 << " +/- " << which.first.second*1e6 << "us " << \
+        "(x" << which.second.first << " +/- " << which.second.second << ")" << std::endl
 
     report(construct_destruct_owner_empty);
     report(construct_destruct_owner);
@@ -185,6 +86,7 @@ void do_benchmarks(const char* type_name) {
 
 int main() {
     do_benchmarks<int>("int");
+    do_benchmarks<float>("float");
     do_benchmarks<std::string>("string");
     do_benchmarks<std::array<int,65'536>>("big_array");
     return 0;

--- a/tests/speed_benchmark.cpp
+++ b/tests/speed_benchmark.cpp
@@ -1,0 +1,191 @@
+#include <memory>
+#include <iostream>
+#include <chrono>
+#include <array>
+#include <string>
+#include <oup/observable_unique_ptr.hpp>
+
+// External functions, the compiler cannot see through. Prevents optimisations.
+template<typename T>
+void use_object(T&) noexcept;
+
+template<typename T>
+struct pointer_traits;
+
+template<typename T>
+struct pointer_traits<std::unique_ptr<T>> {
+    using element_type = T;
+    using ptr_type = std::unique_ptr<T>;
+    using weak_type = T*;
+
+    static ptr_type make_ptr() noexcept { return ptr_type(new element_type); }
+    static ptr_type make_ptr_factory() noexcept { return std::make_unique<element_type>(); }
+    static weak_type make_weak(ptr_type& p) noexcept { return p.get(); }
+    template<typename F>
+    static void deref_weak(weak_type& p, F&& func) noexcept { return func(*p); }
+};
+
+template<typename T>
+struct pointer_traits<std::shared_ptr<T>> {
+    using element_type = T;
+    using ptr_type = std::shared_ptr<T>;
+    using weak_type = std::weak_ptr<T>;
+
+    static ptr_type make_ptr() noexcept { return ptr_type(new element_type); }
+    static ptr_type make_ptr_factory() noexcept { return std::make_shared<element_type>(); }
+    static weak_type make_weak(ptr_type& p) noexcept { return weak_type(p); }
+    template<typename F>
+    static void deref_weak(weak_type& p, F&& func) noexcept { if (auto s = p.lock()) func(*s); }
+};
+
+template<typename T>
+struct pointer_traits<oup::observable_unique_ptr<T>> {
+    using element_type = T;
+    using ptr_type = oup::observable_unique_ptr<T>;
+    using weak_type = oup::observer_ptr<T>;
+
+    static ptr_type make_ptr() noexcept { return ptr_type(new element_type); }
+    static ptr_type make_ptr_factory() noexcept { return oup::make_observable_unique<element_type>(); }
+    static weak_type make_weak(ptr_type& p) noexcept { return weak_type(p); }
+    template<typename F>
+    static void deref_weak(weak_type& p, F&& func) noexcept { return func(*p); }
+};
+
+template<typename T>
+struct pointer_traits<oup::observable_sealed_ptr<T>> {
+    using element_type = T;
+    using ptr_type = oup::observable_sealed_ptr<T>;
+    using weak_type = oup::observer_ptr<T>;
+
+    static ptr_type make_ptr() noexcept { return oup::make_observable_sealed<element_type>(); }
+    static ptr_type make_ptr_factory() noexcept { return oup::make_observable_sealed<element_type>(); }
+    static weak_type make_weak(ptr_type& p) noexcept { return weak_type(p); }
+    template<typename F>
+    static void deref_weak(weak_type& p, F&& func) noexcept { return func(*p); }
+};
+
+template<typename T>
+struct benchmark {
+    using traits = pointer_traits<T>;
+    using element_type = typename traits::element_type;
+    using owner_type = typename traits::ptr_type;
+    using weak_type = typename traits::weak_type;
+
+    owner_type owner;
+    weak_type weak;
+
+    benchmark() : owner(traits::make_ptr()), weak(traits::make_weak(owner)) {}
+
+    void construct_destruct_owner_empty() {
+        auto p = owner_type{};
+        use_object(p);
+    }
+
+    void construct_destruct_owner() {
+        auto p = traits::make_ptr();
+        use_object(p);
+    }
+
+    void construct_destruct_owner_factory() {
+        auto p = traits::make_ptr_factory();
+        use_object(p);
+    }
+
+    void construct_destruct_weak_empty() {
+        auto p = weak_type{};
+        use_object(p);
+    }
+
+    void construct_destruct_weak() {
+        auto wp = traits::make_weak(owner);
+        use_object(wp);
+    }
+
+    void dereference_owner() {
+        use_object(*owner);
+    }
+
+    void dereference_weak() {
+        traits::deref_weak(weak, [](auto& o) { use_object(o); });
+    }
+    void construct_destruct_weak_copy() {
+        auto wp = weak;
+        use_object(wp);
+    }
+};
+
+using timer = std::chrono::high_resolution_clock;
+
+template<typename B, typename F>
+double run_benchmark_for(F&& func) {
+    B bench{};
+
+    auto prev = timer::now();
+    double elapsed = 0.0;
+    double count = 0.0;
+    constexpr std::size_t num_iter = 10'000;
+
+    while (elapsed < 1.0) {
+        for (std::size_t i = 0; i < num_iter; ++i) {
+            func(bench);
+        }
+
+        auto now = timer::now();
+        elapsed += std::chrono::duration_cast<std::chrono::duration<double>>(now - prev).count();
+        count += static_cast<double>(num_iter);
+        std::swap(now, prev);
+    }
+
+    return elapsed/count;
+}
+
+template<typename B, typename F>
+auto run_benchmark(F&& func) {
+    using ref_type = benchmark<std::unique_ptr<typename B::element_type>>;
+    double result = run_benchmark_for<B>(func);
+    double result_ref = run_benchmark_for<ref_type>(func);
+    return std::make_pair(result, result/result_ref);
+}
+
+template<typename T>
+void do_benchmarks_for_ptr(const char* type_name, const char* ptr_name) {
+    using B = benchmark<T>;
+
+    auto construct_destruct_owner_empty = run_benchmark<B>([](auto& b) { return b.construct_destruct_owner_empty(); });
+    auto construct_destruct_owner = run_benchmark<B>([](auto& b) { return b.construct_destruct_owner(); });
+    auto construct_destruct_owner_factory = run_benchmark<B>([](auto& b) { return b.construct_destruct_owner_factory(); });
+    auto dereference_owner = run_benchmark<B>([](auto& b) { return b.dereference_owner(); });
+    auto construct_destruct_weak_empty = run_benchmark<B>([](auto& b) { return b.construct_destruct_weak_empty(); });
+    auto construct_destruct_weak = run_benchmark<B>([](auto& b) { return b.construct_destruct_weak(); });
+    auto construct_destruct_weak_copy = run_benchmark<B>([](auto& b) { return b.construct_destruct_weak_copy(); });
+    auto dereference_weak = run_benchmark<B>([](auto& b) { return b.dereference_weak(); });
+
+    std::cout << ptr_name << "<" << type_name << ">:" << std::endl;
+    #define report(which) std::cout << " - " << #which << ": " << which.first*1e6 << "us (x" << which.second << ")" << std::endl
+
+    report(construct_destruct_owner_empty);
+    report(construct_destruct_owner);
+    report(construct_destruct_owner_factory);
+    report(dereference_owner);
+    report(construct_destruct_weak_empty);
+    report(construct_destruct_weak);
+    report(construct_destruct_weak_copy);
+    report(dereference_weak);
+
+    #undef report
+    std::cout << std::endl;
+}
+
+template<typename T>
+void do_benchmarks(const char* type_name) {
+    do_benchmarks_for_ptr<std::shared_ptr<T>>(type_name, "shared_ptr");
+    do_benchmarks_for_ptr<oup::observable_unique_ptr<T>>(type_name, "observable_unique_ptr");
+    do_benchmarks_for_ptr<oup::observable_sealed_ptr<T>>(type_name, "observable_sealed_ptr");
+}
+
+int main() {
+    do_benchmarks<int>("int");
+    do_benchmarks<std::string>("string");
+    do_benchmarks<std::array<int,65'536>>("big_array");
+    return 0;
+}

--- a/tests/speed_benchmark_common.hpp
+++ b/tests/speed_benchmark_common.hpp
@@ -1,0 +1,96 @@
+#include <memory>
+#include <iostream>
+#include <chrono>
+#include <array>
+#include <string>
+#include <oup/observable_unique_ptr.hpp>
+
+// External functions, the compiler cannot see through. Prevents optimisations.
+template<typename T>
+void use_object(T&) noexcept;
+
+template<typename T>
+struct pointer_traits;
+
+template<typename T>
+struct pointer_traits<std::unique_ptr<T>> {
+    using element_type = T;
+    using ptr_type = std::unique_ptr<T>;
+    using weak_type = T*;
+
+    static ptr_type make_ptr() noexcept { return ptr_type(new element_type); }
+    static ptr_type make_ptr_factory() noexcept { return std::make_unique<element_type>(); }
+    static weak_type make_weak(ptr_type& p) noexcept { return p.get(); }
+    template<typename F>
+    static void deref_weak(weak_type& p, F&& func) noexcept { return func(*p); }
+};
+
+template<typename T>
+struct pointer_traits<std::shared_ptr<T>> {
+    using element_type = T;
+    using ptr_type = std::shared_ptr<T>;
+    using weak_type = std::weak_ptr<T>;
+
+    static ptr_type make_ptr() noexcept { return ptr_type(new element_type); }
+    static ptr_type make_ptr_factory() noexcept { return std::make_shared<element_type>(); }
+    static weak_type make_weak(ptr_type& p) noexcept { return weak_type(p); }
+    template<typename F>
+    static void deref_weak(weak_type& p, F&& func) noexcept { if (auto s = p.lock()) func(*s); }
+};
+
+template<typename T>
+struct pointer_traits<oup::observable_unique_ptr<T>> {
+    using element_type = T;
+    using ptr_type = oup::observable_unique_ptr<T>;
+    using weak_type = oup::observer_ptr<T>;
+
+    static ptr_type make_ptr() noexcept { return ptr_type(new element_type); }
+    static ptr_type make_ptr_factory() noexcept { return oup::make_observable_unique<element_type>(); }
+    static weak_type make_weak(ptr_type& p) noexcept { return weak_type(p); }
+    template<typename F>
+    static void deref_weak(weak_type& p, F&& func) noexcept { return func(*p); }
+};
+
+template<typename T>
+struct pointer_traits<oup::observable_sealed_ptr<T>> {
+    using element_type = T;
+    using ptr_type = oup::observable_sealed_ptr<T>;
+    using weak_type = oup::observer_ptr<T>;
+
+    static ptr_type make_ptr() noexcept { return oup::make_observable_sealed<element_type>(); }
+    static ptr_type make_ptr_factory() noexcept { return oup::make_observable_sealed<element_type>(); }
+    static weak_type make_weak(ptr_type& p) noexcept { return weak_type(p); }
+    template<typename F>
+    static void deref_weak(weak_type& p, F&& func) noexcept { return func(*p); }
+};
+
+template<typename T>
+struct benchmark {
+    using traits = pointer_traits<T>;
+    using element_type = typename traits::element_type;
+    using owner_type = typename traits::ptr_type;
+    using weak_type = typename traits::weak_type;
+
+    owner_type owner;
+    weak_type weak;
+
+    benchmark() : owner(traits::make_ptr()), weak(traits::make_weak(owner)) {}
+
+    void construct_destruct_owner_empty();
+
+    void construct_destruct_owner();
+
+    void construct_destruct_owner_factory();
+
+    void construct_destruct_weak_empty();
+
+    void construct_destruct_weak();
+
+    void construct_destruct_weak_copy();
+
+    void dereference_owner();
+
+    void dereference_weak();
+};
+
+using timer = std::chrono::high_resolution_clock;

--- a/tests/speed_benchmark_utility.cpp
+++ b/tests/speed_benchmark_utility.cpp
@@ -7,33 +7,41 @@ template<typename T>
 void use_object(T&) noexcept {}
 
 template void use_object<int>(int&) noexcept;
+template void use_object<float>(float&) noexcept;
 template void use_object<std::string>(std::string&) noexcept;
 template void use_object<std::array<int,65'536>>(std::array<int,65'536>&) noexcept;
 
 template void use_object<int*>(int*&) noexcept;
+template void use_object<float*>(float*&) noexcept;
 template void use_object<std::string*>(std::string*&) noexcept;
 template void use_object<std::array<int,65'536>*>(std::array<int,65'536>*&) noexcept;
 
 template void use_object<std::unique_ptr<int>>(std::unique_ptr<int>&) noexcept;
+template void use_object<std::unique_ptr<float>>(std::unique_ptr<float>&) noexcept;
 template void use_object<std::unique_ptr<std::string>>(std::unique_ptr<std::string>&) noexcept;
 template void use_object<std::unique_ptr<std::array<int,65'536>>>(std::unique_ptr<std::array<int,65'536>>&) noexcept;
 
 template void use_object<std::shared_ptr<int>>(std::shared_ptr<int>&) noexcept;
+template void use_object<std::shared_ptr<float>>(std::shared_ptr<float>&) noexcept;
 template void use_object<std::shared_ptr<std::string>>(std::shared_ptr<std::string>&) noexcept;
 template void use_object<std::shared_ptr<std::array<int,65'536>>>(std::shared_ptr<std::array<int,65'536>>&) noexcept;
 
 template void use_object<std::weak_ptr<int>>(std::weak_ptr<int>&) noexcept;
+template void use_object<std::weak_ptr<float>>(std::weak_ptr<float>&) noexcept;
 template void use_object<std::weak_ptr<std::string>>(std::weak_ptr<std::string>&) noexcept;
 template void use_object<std::weak_ptr<std::array<int,65'536>>>(std::weak_ptr<std::array<int,65'536>>&) noexcept;
 
 template void use_object<oup::observable_unique_ptr<int>>(oup::observable_unique_ptr<int>&) noexcept;
+template void use_object<oup::observable_unique_ptr<float>>(oup::observable_unique_ptr<float>&) noexcept;
 template void use_object<oup::observable_unique_ptr<std::string>>(oup::observable_unique_ptr<std::string>&) noexcept;
 template void use_object<oup::observable_unique_ptr<std::array<int,65'536>>>(oup::observable_unique_ptr<std::array<int,65'536>>&) noexcept;
 
 template void use_object<oup::observable_sealed_ptr<int>>(oup::observable_sealed_ptr<int>&) noexcept;
+template void use_object<oup::observable_sealed_ptr<float>>(oup::observable_sealed_ptr<float>&) noexcept;
 template void use_object<oup::observable_sealed_ptr<std::string>>(oup::observable_sealed_ptr<std::string>&) noexcept;
 template void use_object<oup::observable_sealed_ptr<std::array<int,65'536>>>(oup::observable_sealed_ptr<std::array<int,65'536>>&) noexcept;
 
 template void use_object<oup::observer_ptr<int>>(oup::observer_ptr<int>&) noexcept;
+template void use_object<oup::observer_ptr<float>>(oup::observer_ptr<float>&) noexcept;
 template void use_object<oup::observer_ptr<std::string>>(oup::observer_ptr<std::string>&) noexcept;
 template void use_object<oup::observer_ptr<std::array<int,65'536>>>(oup::observer_ptr<std::array<int,65'536>>&) noexcept;

--- a/tests/speed_benchmark_utility.cpp
+++ b/tests/speed_benchmark_utility.cpp
@@ -1,0 +1,39 @@
+#include <oup/observable_unique_ptr.hpp>
+#include <array>
+#include <string>
+#include <memory>
+
+template<typename T>
+void use_object(T&) noexcept {}
+
+template void use_object<int>(int&) noexcept;
+template void use_object<std::string>(std::string&) noexcept;
+template void use_object<std::array<int,65'536>>(std::array<int,65'536>&) noexcept;
+
+template void use_object<int*>(int*&) noexcept;
+template void use_object<std::string*>(std::string*&) noexcept;
+template void use_object<std::array<int,65'536>*>(std::array<int,65'536>*&) noexcept;
+
+template void use_object<std::unique_ptr<int>>(std::unique_ptr<int>&) noexcept;
+template void use_object<std::unique_ptr<std::string>>(std::unique_ptr<std::string>&) noexcept;
+template void use_object<std::unique_ptr<std::array<int,65'536>>>(std::unique_ptr<std::array<int,65'536>>&) noexcept;
+
+template void use_object<std::shared_ptr<int>>(std::shared_ptr<int>&) noexcept;
+template void use_object<std::shared_ptr<std::string>>(std::shared_ptr<std::string>&) noexcept;
+template void use_object<std::shared_ptr<std::array<int,65'536>>>(std::shared_ptr<std::array<int,65'536>>&) noexcept;
+
+template void use_object<std::weak_ptr<int>>(std::weak_ptr<int>&) noexcept;
+template void use_object<std::weak_ptr<std::string>>(std::weak_ptr<std::string>&) noexcept;
+template void use_object<std::weak_ptr<std::array<int,65'536>>>(std::weak_ptr<std::array<int,65'536>>&) noexcept;
+
+template void use_object<oup::observable_unique_ptr<int>>(oup::observable_unique_ptr<int>&) noexcept;
+template void use_object<oup::observable_unique_ptr<std::string>>(oup::observable_unique_ptr<std::string>&) noexcept;
+template void use_object<oup::observable_unique_ptr<std::array<int,65'536>>>(oup::observable_unique_ptr<std::array<int,65'536>>&) noexcept;
+
+template void use_object<oup::observable_sealed_ptr<int>>(oup::observable_sealed_ptr<int>&) noexcept;
+template void use_object<oup::observable_sealed_ptr<std::string>>(oup::observable_sealed_ptr<std::string>&) noexcept;
+template void use_object<oup::observable_sealed_ptr<std::array<int,65'536>>>(oup::observable_sealed_ptr<std::array<int,65'536>>&) noexcept;
+
+template void use_object<oup::observer_ptr<int>>(oup::observer_ptr<int>&) noexcept;
+template void use_object<oup::observer_ptr<std::string>>(oup::observer_ptr<std::string>&) noexcept;
+template void use_object<oup::observer_ptr<std::array<int,65'536>>>(oup::observer_ptr<std::array<int,65'536>>&) noexcept;

--- a/tests/speed_benchmark_utility2.cpp
+++ b/tests/speed_benchmark_utility2.cpp
@@ -1,0 +1,67 @@
+#include "speed_benchmark_common.hpp"
+
+template<typename T>
+void benchmark<T>::construct_destruct_owner_empty() {
+    auto p = owner_type{};
+    use_object(p);
+}
+
+template<typename T>
+void benchmark<T>::construct_destruct_owner() {
+    auto p = traits::make_ptr();
+    use_object(p);
+}
+
+template<typename T>
+void benchmark<T>::construct_destruct_owner_factory() {
+    auto p = traits::make_ptr_factory();
+    use_object(p);
+}
+
+template<typename T>
+void benchmark<T>::construct_destruct_weak_empty() {
+    auto p = weak_type{};
+    use_object(p);
+}
+
+template<typename T>
+void benchmark<T>::construct_destruct_weak() {
+    auto wp = traits::make_weak(owner);
+    use_object(wp);
+}
+
+template<typename T>
+void benchmark<T>::construct_destruct_weak_copy() {
+    auto wp = weak;
+    use_object(wp);
+}
+
+template<typename T>
+void benchmark<T>::dereference_owner() {
+    use_object(*owner);
+}
+
+template<typename T>
+void benchmark<T>::dereference_weak() {
+    traits::deref_weak(weak, [](auto& o) { use_object(o); });
+}
+
+template struct benchmark<std::unique_ptr<int>>;
+template struct benchmark<std::unique_ptr<float>>;
+template struct benchmark<std::unique_ptr<std::string>>;
+template struct benchmark<std::unique_ptr<std::array<int,65'536>>>;
+
+template struct benchmark<std::shared_ptr<int>>;
+template struct benchmark<std::shared_ptr<float>>;
+template struct benchmark<std::shared_ptr<std::string>>;
+template struct benchmark<std::shared_ptr<std::array<int,65'536>>>;
+
+template struct benchmark<oup::observable_unique_ptr<int>>;
+template struct benchmark<oup::observable_unique_ptr<float>>;
+template struct benchmark<oup::observable_unique_ptr<std::string>>;
+template struct benchmark<oup::observable_unique_ptr<std::array<int,65'536>>>;
+
+template struct benchmark<oup::observable_sealed_ptr<int>>;
+template struct benchmark<oup::observable_sealed_ptr<float>>;
+template struct benchmark<oup::observable_sealed_ptr<std::string>>;
+template struct benchmark<oup::observable_sealed_ptr<std::array<int,65'536>>>;

--- a/tests/tests_common.hpp
+++ b/tests/tests_common.hpp
@@ -65,10 +65,13 @@ struct test_deleter {
 };
 
 using test_ptr = oup::observable_unique_ptr<test_object>;
+using test_sptr = oup::observable_sealed_ptr<test_object>;
 using test_ptr_derived = oup::observable_unique_ptr<test_object_derived>;
+using test_sptr_derived = oup::observable_sealed_ptr<test_object_derived>;
 using test_ptr_with_deleter = oup::observable_unique_ptr<test_object,test_deleter>;
 using test_ptr_derived_with_deleter = oup::observable_unique_ptr<test_object_derived,test_deleter>;
 using test_ptr_thrower = oup::observable_unique_ptr<test_object_thrower>;
+using test_sptr_thrower = oup::observable_sealed_ptr<test_object_thrower>;
 using test_ptr_thrower_with_deleter = oup::observable_unique_ptr<test_object_thrower,test_deleter>;
 
 using test_optr = oup::observer_ptr<test_object>;


### PR DESCRIPTION
Main changes:
 - `observable_unique_ptr` will now optimize memory usage for empty (stateless) deleters for all versions of C++, not just C++20.
 - `observable_unique_ptr` has been split into `observable_unique_ptr` and `observable_sealed_ptr`. The former preserves the original API, except that allocation optimisation in `make_observable_unique()` has been disabled (it prevents writing a safe `release()` function). The latter has the same API except it is missing `void reset(T*)` and `T* release()`; once a raw pointer is acquired, it is "sealed" inside the smart pointer. This enables the allocation optimisation in `make_observable_sealed()`. You can choose between the two pointers depending on your needs:
    - need to be able to `release()`? use `observable_unique_ptr`.
    - no need to be able to `release()`? use `observable_sealed_ptr` (`reset(T*)` can be achieved by assignment).
 - Added tests and official support for WebAssembly / Emscripten.

Additional changes:
 - Fixed `observer_ptr` not assignable from `observable_unique_ptr` with a custom deleter, and not assignable from other observer pointer of same type.
 - Fixed control block allocated and not freed when constructing `observable_unique_ptr` with a `T*` equal to `nullptr` (but not directly `nullptr`).
 - Fixed `release()` from a `make_observable_unique()` pointer leaving observer pointer with a dangling control block when the user deletes the released pointer.
 - Added speed benchmarks.