### PR TITLE
Add `enable_observer_from_this` and fix self assignment/swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,4 +192,4 @@ Detail of the benchmarks:
 
 ## Alternative implementation
 
-An alternative implementation of an "observable unique pointer" can be found [here](https://www.codeproject.com/articles/1011134/smart-observers-to-use-with-unique-ptr). It does not compile out of the box with gcc unfortunately, but it does contain more features (like creating an observer pointer from a raw `this`) and lacks others (their `make_observable` always performs two allocations). Have a look to check if this better suits your needs.
+An alternative implementation of an "observable unique pointer" can be found [here](https://www.codeproject.com/articles/1011134/smart-observers-to-use-with-unique-ptr). It does not compile out of the box with gcc unfortunately and lacks certain features (their `make_observable` always performs two allocations). Have a look to check if this better suits your needs.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ int main() {
 }
 ```
 
+As with `std::shared_ptr`/`std::weak_ptr`, if you need to obtain an observer pointer to an object when you only have `this` (i.e., from a member function), you can inherit from `oup::enable_observer_from_this<T>` to gain access to the `observer_from_this()` member function. This function will return a valid observer pointer as long as the object is owned by a unique or sealed pointer, and will return `nullptr` in all other cases.
+
 
 ## Limitations
 

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -772,7 +772,7 @@ observable_sealed_ptr<T> make_observable_sealed(Args&& ... args) {
     // Allocate memory
     constexpr std::size_t block_size = sizeof(block_type);
     constexpr std::size_t object_size = sizeof(T);
-    std::byte* buffer = new std::byte[block_size + object_size];
+    std::byte* buffer = reinterpret_cast<std::byte*>(operator new(block_size + object_size));
 
     try {
         // Construct control block and object
@@ -784,7 +784,7 @@ observable_sealed_ptr<T> make_observable_sealed(Args&& ... args) {
     } catch (...) {
         // Exception thrown during object construction,
         // clean up memory and let exception propagate
-        delete[] buffer;
+        delete buffer;
         throw;
     }
 }

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -1183,7 +1183,7 @@ template<typename T>
 class enable_observer_from_this {
     mutable observer_ptr<T> this_observer;
 
-    // Friendship is required for assignement of the observer.
+    // Friendship is required for assignment of the observer.
     template<typename U, typename D>
     friend class details::observable_unique_ptr_base;
 

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -292,6 +292,10 @@ public:
     /** \param other The other pointer to swap with
     */
     void swap(observable_unique_ptr_base& other) noexcept {
+        if (&other == this) {
+            return;
+        }
+
         using std::swap;
         swap(block, other.block);
         swap(ptr_deleter, other.ptr_deleter);
@@ -973,6 +977,10 @@ public:
     /** \param value The existing weak pointer to copy
     */
     observer_ptr& operator=(const observer_ptr& value) noexcept {
+        if (&value == this) {
+            return *this;
+        }
+
         if (data) {
             pop_ref_();
         }
@@ -993,6 +1001,10 @@ public:
     */
     template<typename U, typename enable = std::enable_if_t<std::is_convertible_v<U*, T*>>>
     observer_ptr& operator=(const observer_ptr<U>& value) noexcept {
+        if (&value == this) {
+            return *this;
+        }
+
         if (data) {
             pop_ref_();
         }
@@ -1114,6 +1126,10 @@ public:
     /** \param other The other pointer to swap with
     */
     void swap(observer_ptr& other) noexcept {
+        if (&other == this) {
+            return;
+        }
+
         using std::swap;
         swap(block, other.block);
         swap(data, other.data);

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -15,6 +15,7 @@ template<typename T>
 class enable_observer_from_this;
 
 namespace details {
+
 struct control_block {
     enum flag_elements {
         flag_none = 0,
@@ -37,6 +38,7 @@ template<typename T, typename Deleter>
 struct ptr_and_deleter : Deleter {
     T* data = nullptr;
 };
+
 }
 
 /// Simple default deleter
@@ -78,6 +80,9 @@ struct placement_delete
 };
 
 namespace details {
+
+struct enable_observer_from_this_base {};
+
 template<typename T, typename Deleter = oup::default_delete<T>>
 class observable_unique_ptr_base {
 protected:
@@ -111,7 +116,7 @@ protected:
 
     /// Fill in the observer pointer for objects inheriting from enable_observer_from_this.
     void set_this_observer_() noexcept {
-        if constexpr (std::is_base_of_v<enable_observer_from_this<T>, T>) {
+        if constexpr (std::is_base_of_v<details::enable_observer_from_this_base, T>) {
             if (ptr_deleter.data) {
                 ptr_deleter.data->this_observer.set_data_(block, ptr_deleter.data);
                 ++block->refcount;
@@ -362,6 +367,7 @@ public:
         return ptr_deleter.data != nullptr;
     }
 };
+
 }
 
 /// Unique-ownership smart pointer, can be observed by observer_ptr, ownership can be released.
@@ -1180,7 +1186,7 @@ bool operator!= (const observer_ptr<T>& first, const observer_ptr<U>& second) no
 *   type of smart pointer, then observer_from_this() will return nullptr.
 */
 template<typename T>
-class enable_observer_from_this {
+class enable_observer_from_this : public details::enable_observer_from_this_base {
     mutable observer_ptr<T> this_observer;
 
     // Friendship is required for assignment of the observer.

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -3055,6 +3055,57 @@ TEST_CASE("observer from this after move assignment sealed", "[observer_from_thi
     REQUIRE(mem_track.double_del() == 0u);
 }
 
+TEST_CASE("observer from this after release", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr_from_this ptr1{new test_object_observer_from_this};
+        test_object_observer_from_this* ptr2 = ptr1.release();
+        const test_object_observer_from_this* cptr2 = ptr2;
+
+        test_optr_from_this optr_from_this = ptr2->observer_from_this();
+        test_optr_from_this_const optr_from_this_const = cptr2->observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == true);
+        REQUIRE(optr_from_this_const.expired() == true);
+        REQUIRE(optr_from_this.get() == nullptr);
+        REQUIRE(optr_from_this_const.get() == nullptr);
+
+        delete ptr2;
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer from this after release and reset", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr_from_this ptr1{new test_object_observer_from_this};
+        test_object_observer_from_this* ptr2 = ptr1.release();
+        const test_object_observer_from_this* cptr2 = ptr2;
+
+        test_ptr_from_this ptr3;
+        ptr3.reset(ptr2);
+
+        test_optr_from_this optr_from_this = ptr2->observer_from_this();
+        test_optr_from_this_const optr_from_this_const = cptr2->observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == ptr2);
+        REQUIRE(optr_from_this_const.get() == ptr2);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
 TEST_CASE("observer from this stack", "[observer_from_this]") {
     memory_tracker mem_track;
 

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -748,6 +748,102 @@ TEST_CASE("owner move assignment operator valid to valid with deleter", "[owner_
     REQUIRE(mem_track.double_del() == 0u);
 }
 
+TEST_CASE("owner move assignment operator self to self", "[owner_assignment]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr ptr(new test_object);
+        ptr = std::move(ptr);
+        REQUIRE(instances == 0);
+        REQUIRE(ptr.get() == nullptr);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("owner move assignment operator self to self sealed", "[owner_assignment]") {
+    memory_tracker mem_track;
+
+    {
+        test_sptr ptr = oup::make_observable_sealed<test_object>();
+        ptr = std::move(ptr);
+        REQUIRE(instances == 0);
+        REQUIRE(ptr.get() == nullptr);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("owner move assignment operator self to self with deleter", "[owner_assignment]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr_with_deleter ptr(new test_object, test_deleter{42});
+        ptr = std::move(ptr);
+        REQUIRE(instances == 0);
+        REQUIRE(ptr.get() == nullptr);
+        REQUIRE(instances_deleter == 1);
+        REQUIRE(ptr.get_deleter().state_ == 0);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(instances_deleter == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("owner move assignment operator self to self empty", "[owner_assignment]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr ptr;
+        ptr = std::move(ptr);
+        REQUIRE(instances == 0);
+        REQUIRE(ptr.get() == nullptr);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("owner move assignment operator self to self empty sealed", "[owner_assignment]") {
+    memory_tracker mem_track;
+
+    {
+        test_sptr ptr;
+        ptr = std::move(ptr);
+        REQUIRE(instances == 0);
+        REQUIRE(ptr.get() == nullptr);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("owner move assignment operator self to self empty with deleter", "[owner_assignment]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr_with_deleter ptr;
+        ptr = std::move(ptr);
+        REQUIRE(instances == 0);
+        REQUIRE(ptr.get() == nullptr);
+        REQUIRE(instances_deleter == 1);
+        REQUIRE(ptr.get_deleter().state_ == 0);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(instances_deleter == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
 TEST_CASE("owner comparison valid ptr vs nullptr", "[owner_comparison]") {
     memory_tracker mem_track;
 
@@ -2118,6 +2214,59 @@ TEST_CASE("observer copy assignment operator empty to empty", "[observer_assignm
     REQUIRE(mem_track.double_del() == 0u);
 }
 
+TEST_CASE("observer copy assignment operator self to self", "[observer_assignment]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr ptr_owner{new test_object};
+        test_optr ptr{ptr_owner};
+        ptr = ptr;
+        REQUIRE(instances == 1);
+        REQUIRE(ptr.get() != nullptr);
+        REQUIRE(ptr.expired() == false);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer copy assignment operator self to self expired", "[observer_assignment]") {
+    memory_tracker mem_track;
+
+    {
+        test_optr ptr;
+        {
+            test_ptr ptr_owner{new test_object};
+            ptr = ptr_owner;
+        }
+        ptr = ptr;
+        REQUIRE(instances == 0);
+        REQUIRE(ptr.get() == nullptr);
+        REQUIRE(ptr.expired() == true);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer copy assignment operator self to self empty", "[observer_assignment]") {
+    memory_tracker mem_track;
+
+    {
+        test_optr ptr;
+        ptr = ptr;
+        REQUIRE(instances == 0);
+        REQUIRE(ptr.get() == nullptr);
+        REQUIRE(ptr.expired() == true);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
 TEST_CASE("observer move assignment operator valid to empty", "[observer_assignment]") {
     memory_tracker mem_track;
 
@@ -2183,6 +2332,59 @@ TEST_CASE("observer move assignment operator empty to empty", "[observer_assignm
         }
 
         REQUIRE(instances == 0);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer move assignment operator self to self", "[observer_assignment]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr ptr_owner{new test_object};
+        test_optr ptr{ptr_owner};
+        ptr = std::move(ptr);
+        REQUIRE(instances == 1);
+        REQUIRE(ptr.get() == nullptr);
+        REQUIRE(ptr.expired() == true);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer move assignment operator self to self expired", "[observer_assignment]") {
+    memory_tracker mem_track;
+
+    {
+        test_optr ptr;
+        {
+            test_ptr ptr_owner{new test_object};
+            ptr = ptr_owner;
+        }
+        ptr = std::move(ptr);
+        REQUIRE(instances == 0);
+        REQUIRE(ptr.get() == nullptr);
+        REQUIRE(ptr.expired() == true);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer move assignment operator self to self empty", "[observer_assignment]") {
+    memory_tracker mem_track;
+
+    {
+        test_optr ptr;
+        ptr = std::move(ptr);
+        REQUIRE(instances == 0);
+        REQUIRE(ptr.get() == nullptr);
+        REQUIRE(ptr.expired() == true);
     }
 
     REQUIRE(instances == 0);

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -2961,6 +2961,28 @@ TEST_CASE("observer from this sealed", "[observer_from_this]") {
     REQUIRE(mem_track.double_del() == 0u);
 }
 
+TEST_CASE("observer from this derived", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr_from_this_derived ptr{new test_object_observer_from_this_derived};
+        const test_ptr_from_this_derived& cptr = ptr;
+
+        test_optr_from_this optr_from_this = ptr->observer_from_this();
+        test_optr_from_this_const optr_from_this_const = cptr->observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == ptr.get());
+        REQUIRE(optr_from_this_const.get() == ptr.get());
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
 TEST_CASE("observer from this after move", "[observer_from_this]") {
     memory_tracker mem_track;
 

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -1387,6 +1387,52 @@ TEST_CASE("owner swap two instances with deleter", "[owner_utility]") {
     REQUIRE(mem_track.double_del() == 0u);
 }
 
+TEST_CASE("owner swap self", "[owner_utility]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr ptr(new test_object);
+        ptr.swap(ptr);
+        REQUIRE(instances == 1);
+        REQUIRE(ptr.get() != nullptr);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("owner swap self sealed", "[owner_utility]") {
+    memory_tracker mem_track;
+
+    {
+        test_sptr ptr = oup::make_observable_sealed<test_object>();
+        ptr.swap(ptr);
+        REQUIRE(instances == 1);
+        REQUIRE(ptr.get() != nullptr);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("owner swap self with deleter", "[owner_utility]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr_with_deleter ptr(new test_object, test_deleter{43});
+        ptr.swap(ptr);
+        REQUIRE(instances == 1);
+        REQUIRE(ptr.get() != nullptr);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(instances_deleter == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
 TEST_CASE("owner dereference", "[owner_utility]") {
     memory_tracker mem_track;
 
@@ -2074,6 +2120,23 @@ TEST_CASE("observer swap two different instances", "[observer_utility]") {
         REQUIRE(ptr_orig.get() == ptr_owner2.get());
         REQUIRE(ptr.get() == ptr_owner1.get());
         REQUIRE(ptr_orig.expired() == false);
+        REQUIRE(ptr.expired() == false);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer swap self", "[observer_utility]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr ptr_owner(new test_object);
+        test_optr ptr(ptr_owner);
+        ptr.swap(ptr);
+        REQUIRE(instances == 1);
+        REQUIRE(ptr.get() == ptr_owner.get());
         REQUIRE(ptr.expired() == false);
     }
 

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -2916,3 +2916,163 @@ TEST_CASE("pointers in vector", "[system_tests]") {
     REQUIRE(mem_track.leaks() == 0u);
     REQUIRE(mem_track.double_del() == 0u);
 }
+
+TEST_CASE("observer from this", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr_from_this ptr{new test_object_observer_from_this};
+        const test_ptr_from_this& cptr = ptr;
+
+        test_optr_from_this optr_from_this = ptr->observer_from_this();
+        test_optr_from_this_const optr_from_this_const = cptr->observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == ptr.get());
+        REQUIRE(optr_from_this_const.get() == ptr.get());
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer from this sealed", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        test_sptr_from_this ptr = oup::make_observable_sealed<test_object_observer_from_this>();
+        const test_sptr_from_this& cptr = ptr;
+
+        test_optr_from_this optr_from_this = ptr->observer_from_this();
+        test_optr_from_this_const optr_from_this_const = cptr->observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == ptr.get());
+        REQUIRE(optr_from_this_const.get() == ptr.get());
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer from this after move", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr_from_this ptr1{new test_object_observer_from_this};
+        test_ptr_from_this ptr2{std::move(ptr1)};
+        const test_ptr_from_this& cptr2 = ptr2;
+
+        test_optr_from_this optr_from_this = ptr2->observer_from_this();
+        test_optr_from_this_const optr_from_this_const = cptr2->observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == ptr2.get());
+        REQUIRE(optr_from_this_const.get() == ptr2.get());
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer from this after move sealed", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        test_sptr_from_this ptr1 = oup::make_observable_sealed<test_object_observer_from_this>();
+        test_sptr_from_this ptr2{std::move(ptr1)};
+        const test_sptr_from_this& cptr2 = ptr2;
+
+        test_optr_from_this optr_from_this = ptr2->observer_from_this();
+        test_optr_from_this_const optr_from_this_const = cptr2->observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == ptr2.get());
+        REQUIRE(optr_from_this_const.get() == ptr2.get());
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer from this after move assignment", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr_from_this ptr1{new test_object_observer_from_this};
+        test_ptr_from_this ptr2;
+        ptr2 = std::move(ptr1);
+
+        const test_ptr_from_this& cptr2 = ptr2;
+        test_optr_from_this optr_from_this = ptr2->observer_from_this();
+        test_optr_from_this_const optr_from_this_const = cptr2->observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == ptr2.get());
+        REQUIRE(optr_from_this_const.get() == ptr2.get());
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer from this after move assignment sealed", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        test_sptr_from_this ptr1 = oup::make_observable_sealed<test_object_observer_from_this>();
+        test_sptr_from_this ptr2;
+        ptr2 = std::move(ptr1);
+        const test_sptr_from_this& cptr2 = ptr2;
+
+        test_optr_from_this optr_from_this = ptr2->observer_from_this();
+        test_optr_from_this_const optr_from_this_const = cptr2->observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == ptr2.get());
+        REQUIRE(optr_from_this_const.get() == ptr2.get());
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer from this stack", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        test_object_observer_from_this obj;
+        const test_object_observer_from_this& cobj = obj;
+
+        test_optr_from_this optr_from_this = obj.observer_from_this();
+        test_optr_from_this_const optr_from_this_const = cobj.observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == true);
+        REQUIRE(optr_from_this_const.expired() == true);
+        REQUIRE(optr_from_this.get() == nullptr);
+        REQUIRE(optr_from_this_const.get() == nullptr);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}

--- a/tests/tests_common.hpp
+++ b/tests/tests_common.hpp
@@ -42,6 +42,9 @@ struct test_object_observer_from_this :
     public test_object,
     public oup::enable_observer_from_this<test_object_observer_from_this> {};
 
+struct test_object_observer_from_this_derived :
+    public test_object_observer_from_this {};
+
 struct test_deleter {
     int state_ = 0;
 
@@ -79,8 +82,12 @@ using test_sptr_thrower = oup::observable_sealed_ptr<test_object_thrower>;
 using test_ptr_thrower_with_deleter = oup::observable_unique_ptr<test_object_thrower,test_deleter>;
 using test_ptr_from_this = oup::observable_unique_ptr<test_object_observer_from_this>;
 using test_sptr_from_this = oup::observable_sealed_ptr<test_object_observer_from_this>;
+using test_ptr_from_this_derived = oup::observable_unique_ptr<test_object_observer_from_this_derived>;
+using test_sptr_from_this_derived = oup::observable_sealed_ptr<test_object_observer_from_this_derived>;
 
 using test_optr = oup::observer_ptr<test_object>;
 using test_optr_derived = oup::observer_ptr<test_object_derived>;
 using test_optr_from_this = oup::observer_ptr<test_object_observer_from_this>;
 using test_optr_from_this_const = oup::observer_ptr<const test_object_observer_from_this>;
+using test_optr_from_this_derived = oup::observer_ptr<test_object_observer_from_this_derived>;
+using test_optr_from_this_derived_const = oup::observer_ptr<const test_object_observer_from_this_derived>;

--- a/tests/tests_common.hpp
+++ b/tests/tests_common.hpp
@@ -38,6 +38,10 @@ struct test_object_thrower {
     test_object_thrower& operator=(test_object_thrower&&) = delete;
 };
 
+struct test_object_observer_from_this :
+    public test_object,
+    public oup::enable_observer_from_this<test_object_observer_from_this> {};
+
 struct test_deleter {
     int state_ = 0;
 
@@ -73,6 +77,10 @@ using test_ptr_derived_with_deleter = oup::observable_unique_ptr<test_object_der
 using test_ptr_thrower = oup::observable_unique_ptr<test_object_thrower>;
 using test_sptr_thrower = oup::observable_sealed_ptr<test_object_thrower>;
 using test_ptr_thrower_with_deleter = oup::observable_unique_ptr<test_object_thrower,test_deleter>;
+using test_ptr_from_this = oup::observable_unique_ptr<test_object_observer_from_this>;
+using test_sptr_from_this = oup::observable_sealed_ptr<test_object_observer_from_this>;
 
 using test_optr = oup::observer_ptr<test_object>;
 using test_optr_derived = oup::observer_ptr<test_object_derived>;
+using test_optr_from_this = oup::observer_ptr<test_object_observer_from_this>;
+using test_optr_from_this_const = oup::observer_ptr<const test_object_observer_from_this>;


### PR DESCRIPTION
This PR brings `enable_observer_from_this`, to create observer pointer from within a class, and fixes bugs related to self assignment and self swap. It also fixes a mismatch between `new[]` and `delete` for the sealed pointer, which was reported by valgrind.