### PR TITLE
Update and bug fixes for alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,44 +179,46 @@ Detail of the benchmarks:
  - Create observer copy: construct a new observer pointer from another observer pointer.
  - Dereference observer: get a reference to the underlying object from an observer pointer.
 
-*Compiler: gcc 9.4.0, std: libstdc++-9, oup: 0.7.1, OS: linux 5.15.0, CPU: Ryzen 5 2600:*
+The benchmarks were last ran for oup v0.7.1.
+
+*Compiler: gcc 9.4.0, std: libstdc++-9, OS: linux 5.15.0, CPU: Ryzen 5 2600:*
 
 | Pointer               | raw/unique | weak/shared | observer/obs_unique | observer/obs_sealed |
 | ---                   | ---        | ---         | ---                 | ---                 |
-| Create owner empty    | 1          | 1.0         | 1.0                 | 1.1                 |
+| Create owner empty    | 1          | 1.1         | 1.1                 | 1.2                 |
 | Create owner          | 1          | 2.1         | 1.7                 | N/A                 |
-| Create owner factory  | 1          | 1.3         | 1.7                 | 1.4                 |
-| Dereference owner     | 1          | 1.1         | 1.0                 | 1.0                 |
-| Create observer empty | 1          | 1.3         | 1.2                 | 1.2                 |
-| Create observer       | 1          | 1.7         | 1.6                 | 1.6                 |
-| Create observer copy  | 1          | 1.6         | 1.6                 | 1.8                 |
-| Dereference observer  | 1          | 3.9         | 1.1                 | 1.1                 |
+| Create owner factory  | 1          | 1.3         | 1.7                 | 1.1                 |
+| Dereference owner     | 1          | 1.0         | 1.0                 | 1.1                 |
+| Create observer empty | 1          | 1.1         | 1.2                 | 1.2                 |
+| Create observer       | 1          | 1.6         | 1.6                 | 1.6                 |
+| Create observer copy  | 1          | 1.7         | 1.6                 | 1.6                 |
+| Dereference observer  | 1          | 3.5         | 1.0                 | 1.0                 |
 
-*Compiler: MSVC 16.11.3, std: MS-STL, oup: 0.4.0, OS: Windows 10.0.19043, CPU: i7-7800x:*
+*Compiler: MSVC 16.11.3, std: MS-STL, OS: Windows 10.0.19043, CPU: i7-7800x:*
 
-| Pointer                  | raw/unique | weak/shared | observer/obs_unique | observer/obs_sealed |
-|--------------------------|------------|-------------|---------------------|---------------------|
-| Create owner empty       |     1      |     1.1     |         1.1         |         1.1         |
-| Create owner             |     1      |     2.2     |         2.0         |         N/A         |
-| Create owner factory     |     1      |     1.3     |         2.0         |         1.4         |
-| Dereference owner        |     1      |     0.8     |         1.8         |         1.5         |
-| Create observer empty    |     1      |     1.1     |         1.2         |         1.2         |
-| Create observer          |     1      |     5.6     |         1.5         |         1.3         |
-| Create observer copy     |     1      |     6.2     |         1.4         |         1.3         |
-| Dereference observer     |     1      |     11      |         1.5         |         1.1         |
+| Pointer               | raw/unique | weak/shared | observer/obs_unique | observer/obs_sealed |
+| ---                   | ---        | ---         | ---                 | ---                 |
+| Create owner empty    | 1          | 1.4         | 1.8                 | 1.5                 |
+| Create owner          | 1          | 2.2         | 2.9                 | N/A                 |
+| Create owner factory  | 1          | 1.2         | 2.2                 | 0.9                 |
+| Dereference owner     | 1          | 0.7         | 1.3                 | 1.0                 |
+| Create observer empty | 1          | 1.6         | 1.0                 | 0.8                 |
+| Create observer       | 1          | 5.3         | 1.6                 | 1.6                 |
+| Create observer copy  | 1          | 5.3         | 1.4                 | 1.5                 |
+| Dereference observer  | 1          | 9.4         | 1.4                 | 0.8                 |
 
-*Compiler: Emscripten 2.0.16, std: libc++, oup: 0.4.0, OS: Node.js 14.15.5 + linux kernel 5.1.0, CPU: Ryzen 5 2600:*
+*Compiler: Emscripten 2.0.34, std: libc++, OS: Node.js 14.15.5 + linux kernel 5.1.0, CPU: Ryzen 5 2600:*
 
-| Pointer                  | raw/unique | weak/shared | observer/obs_unique | observer/obs_sealed |
-|--------------------------|------------|-------------|---------------------|---------------------|
-| Create owner empty       |     1      |     20      |         1.2         |         1           |
-| Create owner             |     1      |     1.6     |         1.6         |         N/A         |
-| Create owner factory     |     1      |     1.1     |         1.6         |         1           |
-| Dereference owner        |     1      |     1       |         1           |         1           |
-| Create observer empty    |     1      |     35      |         1.8         |         1.7         |
-| Create observer          |     1      |     36      |         2.4         |         2.5         |
-| Create observer copy     |     1      |     41      |         2.3         |         2.3         |
-| Dereference observer     |     1      |     114     |         1           |         1           |
+| Pointer               | raw/unique | weak/shared | observer/obs_unique | observer/obs_sealed |
+| ---                   | ---        | ---         | ---                 | ---                 |
+| Create owner empty    | 1          | 6.9         | 1.1                 | 1.0                 |
+| Create owner          | 1          | 1.8         | 1.6                 | N/A                 |
+| Create owner factory  | 1          | 1.2         | 1.7                 | 1.0                 |
+| Dereference owner     | 1          | 1.0         | 1.0                 | 1.0                 |
+| Create observer empty | 1          | 11.4        | 1.6                 | 1.6                 |
+| Create observer       | 1          | 14.8        | 2.3                 | 2.3                 |
+| Create observer copy  | 1          | 14.9        | 2.3                 | 2.5                 |
+| Dereference observer  | 1          | 38.7        | 1.0                 | 1.0                 |
 
 
 ## Alternative implementation

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Finally, because this library uses no global state (beyond the standard allocato
 
 ## Comparison spreadsheet
 
-In this comparison spreadsheet, the raw pointer `T*` is assumed to never be owning, and used only to observe an existing object (which may or may not have been deleted). The stack and heap sizes were measured with gcc 9.3.0 and libstdc++.
+In this comparison spreadsheet, the raw pointer `T*` is assumed to never be owning, and used only to observe an existing object (which may or may not have been deleted). Unless otherwise specified, the stack and heap sizes were measured with gcc 9.4.0 and libstdc++-9.
 
 Labels:
  - raw: `T*`
@@ -146,7 +146,7 @@ Labels:
 | Number of heap alloc.    | 0    | 0      | 0        | 1      | 1/2(4) | 2          | 1          |
 | Size in bytes (64 bit)   |      |        |          |        |        |            |            |
 |  - Stack (per instance)  | 8    | 16     | 16       | 8      | 16     | 16         | 16         |
-|  - Heap (shared)         | 0    | 0      | 0        | 0      | 24     | 4          | 4          |
+|  - Heap (shared)         | 0    | 0      | 0        | 0      | 24(5)  | 4          | 4(6)       |
 |  - Total                 | 8    | 16     | 16       | 8      | 40     | 20         | 20         |
 | Size in bytes (32 bit)   |      |        |          |        |        |            |            |
 |  - Stack (per instance)  | 4    | 8      | 8        | 4      | 8      | 8          | 8          |
@@ -159,6 +159,8 @@ Notes:
  - (2) Not if using `std::make_shared()`.
  - (3) Not defined by the C++ standard. In practice, libstdc++ stores its reference count on an `_Atomic_word`, which for a common 64bit linux platform is a 4 byte signed integer, hence the limit will be 2^31 - 1. Microsoft's STL uses `_Atomic_counter_t`, which for a 64bit Windows platform is 4 bytes unsigned integer, hence the limit will be 2^32 - 1.
  - (4) 2 by default, or 1 if using `std::make_shared()`.
+ - (5) When using `std::make_shared()`, this can get as low as 16 bytes, or larger than 24 bytes, depending on the size and alignment requirements of the object type. This behavior is shared by libstdc++ and MS-STL.
+ - (6) Can get larger than 4 depending on the alignment requirements of the object type.
 
 
 ## Speed benchmarks

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Notes:
 
 Labels are the same as in the comparison spreadsheet. The speed benchmarks were compiled with all optimizations turned on (except LTO). Speed is measured relative to `std::unique_ptr<T>` used as owner pointer, and `T*` used as observer pointer, which should be the fastest possible implementation (but obviously the one with least safety).
 
-You can run the benchmarks yourself, they are located in `tests/speed_benchmark.cpp`. The benchmark executable runs tests for three object types: `int`, `float`, `std::string`, and `std::array<int,65'536>`, to simulate objects of various allocation cost. The timings below are the worst-case values measured across all object types, which should be most relevant to highlight the overhead from the pointer itself (and erases flukes from the benchmarking framework). In real life scenarios, the actual measured overhead will be substantially lower, as actual business logic is likely to dominate the time budget.
+You can run the benchmarks yourself, they are located in `tests/speed_benchmark.cpp`. The benchmark executable runs tests for three object types: `int`, `float`, `std::string`, and `std::array<int,65'536>`, to simulate objects of various allocation cost. The timings below are the median values measured across all object types, which should be most relevant to highlight the overhead from the pointer itself (and erases flukes from the benchmarking framework). In real life scenarios, the actual measured overhead will be substantially lower, as actual business logic is likely to dominate the time budget.
 
 Detail of the benchmarks:
  - Create owner empty: default-construct an owner pointer (to nullptr).
@@ -179,22 +179,20 @@ Detail of the benchmarks:
  - Create observer copy: construct a new observer pointer from another observer pointer.
  - Dereference observer: get a reference to the underlying object from an observer pointer.
 
-The benchmarks were last ran for v0.4.0.
+*Compiler: gcc 9.4.0, std: libstdc++-9, oup: 0.7.1, OS: linux 5.15.0, CPU: Ryzen 5 2600:*
 
-*Compiler: gcc 9.3.0, std: libstdc++, OS: linux 5.1.0, CPU: Ryzen 5 2600:*
+| Pointer               | raw/unique | weak/shared | observer/obs_unique | observer/obs_sealed |
+| ---                   | ---        | ---         | ---                 | ---                 |
+| Create owner empty    | 1          | 1.0         | 1.0                 | 1.1                 |
+| Create owner          | 1          | 2.1         | 1.7                 | N/A                 |
+| Create owner factory  | 1          | 1.3         | 1.7                 | 1.4                 |
+| Dereference owner     | 1          | 1.1         | 1.0                 | 1.0                 |
+| Create observer empty | 1          | 1.3         | 1.2                 | 1.2                 |
+| Create observer       | 1          | 1.7         | 1.6                 | 1.6                 |
+| Create observer copy  | 1          | 1.6         | 1.6                 | 1.8                 |
+| Dereference observer  | 1          | 3.9         | 1.1                 | 1.1                 |
 
-| Pointer                  | raw/unique | weak/shared | observer/obs_unique | observer/obs_sealed |
-|--------------------------|------------|-------------|---------------------|---------------------|
-| Create owner empty       |     1      |     1.1     |         1.1         |         1.1         |
-| Create owner             |     1      |     2.2     |         1.9         |         N/A         |
-| Create owner factory     |     1      |     1.3     |         1.8         |         1.3         |
-| Dereference owner        |     1      |     1       |         1           |         1           |
-| Create observer empty    |     1      |     1.2     |         1.2         |         1.3         |
-| Create observer          |     1      |     1.5     |         1.6         |         1.6         |
-| Create observer copy     |     1      |     1.7     |         1.7         |         1.7         |
-| Dereference observer     |     1      |     4.8     |         1.2         |         1.3         |
-
-*Compiler: MSVC 16.11.3, std: MS-STL, OS: Windows 10.0.19043, CPU: i7-7800x:*
+*Compiler: MSVC 16.11.3, std: MS-STL, oup: 0.4.0, OS: Windows 10.0.19043, CPU: i7-7800x:*
 
 | Pointer                  | raw/unique | weak/shared | observer/obs_unique | observer/obs_sealed |
 |--------------------------|------------|-------------|---------------------|---------------------|
@@ -207,7 +205,7 @@ The benchmarks were last ran for v0.4.0.
 | Create observer copy     |     1      |     6.2     |         1.4         |         1.3         |
 | Dereference observer     |     1      |     11      |         1.5         |         1.1         |
 
-*Compiler: Emscripten 2.0.16, std: libc++, OS: Node.js 14.15.5 + linux kernel 5.1.0, CPU: Ryzen 5 2600:*
+*Compiler: Emscripten 2.0.16, std: libc++, oup: 0.4.0, OS: Node.js 14.15.5 + linux kernel 5.1.0, CPU: Ryzen 5 2600:*
 
 | Pointer                  | raw/unique | weak/shared | observer/obs_unique | observer/obs_sealed |
 |--------------------------|------------|-------------|---------------------|---------------------|

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -799,6 +799,8 @@ public:
  */
 template<typename T, typename Policy, typename... Args>
 auto make_observable(Args&&... args) {
+    static_assert(!std::is_reference_v<T>, "cannot create a pointer to a reference");
+
     using observer_policy    = typename Policy::observer_policy;
     using control_block_type = basic_control_block<observer_policy>;
     using decayed_type       = std::decay_t<T>;

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -829,9 +829,11 @@ auto make_observable(Args&&... args) {
         }
     } else {
         // Pre-allocate memory
-        constexpr std::size_t block_size  = sizeof(control_block_type);
-        constexpr std::size_t object_size = sizeof(object_type);
-        constexpr std::size_t obj_offset  = block_size;
+        constexpr std::size_t block_size    = sizeof(control_block_type);
+        constexpr std::size_t object_size   = sizeof(object_type);
+        constexpr std::size_t object_align  = alignof(object_type);
+        constexpr std::size_t align_padding = object_align - 1 - ((block_size - 1) % object_align);
+        constexpr std::size_t obj_offset    = block_size + align_padding;
 
         std::byte* buffer = reinterpret_cast<std::byte*>(operator new(obj_offset + object_size));
 

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -841,7 +841,7 @@ auto make_observable(Args&&... args) {
             if constexpr (
                 has_enable_observer_from_this<T, Policy> &&
                 queries::eoft_base_constructor_needs_block()) {
-                // The object as a constructor that can take a control block; just give it
+                // The object has a constructor that can take a control block; just give it
                 ptr = new (buffer + block_size) decayed_type(*block, std::forward<Args>(args)...);
 
                 // Make owner pointer

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -13,7 +13,7 @@ namespace oup {
 /// Exception thrown for failed observer_from_this().
 struct bad_observer_from_this : std::exception {
     const char* what() const noexcept override {
-        return "observer_from_this() called with uninitialised control block";
+        return "observer_from_this() called with uninitialized control block";
     }
 };
 

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -346,9 +346,10 @@ constexpr bool has_enable_observer_from_this =
  * \see observable_unique_ptr
  * \see observable_sealed_ptr
  * \see observer_ptr
- * \see basic_enable_observer_from_this
+ * \see basic_observer_ptr
  * \see enable_observer_from_this_unique
  * \see enable_observer_from_this_sealed
+ * \see basic_enable_observer_from_this
  */
 template<typename T, typename Deleter, typename Policy>
 class basic_observable_ptr final {
@@ -914,9 +915,9 @@ bool operator!=(
 /**
  * \brief Non-owning smart pointer that observes a @ref basic_observable_ptr.
  * \see observer_ptr
- * \see basic_observable_ptr
  * \see observable_unique_ptr
  * \see observable_sealed_ptr
+ * \see basic_observable_ptr
  */
 template<typename T, typename Policy>
 class basic_observer_ptr final {
@@ -1413,7 +1414,10 @@ struct inherit_as_virtual<false, T> : T {
  *
  * \see enable_observer_from_this_unique
  * \see enable_observer_from_this_sealed
+ * \see observable_unique_ptr
+ * \see observable_sealed_ptr
  * \see basic_observable_ptr
+ * \see observer_ptr
  * \see basic_observer_ptr
  */
 template<typename T, typename Policy>

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -589,7 +589,7 @@ public:
         basic_observable_ptr(get_or_create_block_from_object_(value), value) {
     } catch (...) {
         // Allocation of control block failed, delete input pointer and rethrow
-        ptr_deleter(value);
+        Deleter{}(value);
     }
 
     /**

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -800,6 +800,8 @@ public:
 template<typename T, typename Policy, typename... Args>
 auto make_observable(Args&&... args) {
     static_assert(!std::is_reference_v<T>, "cannot create a pointer to a reference");
+    static_assert(!std::is_array_v<T>, "cannot create a pointer to an array");
+    static_assert(!std::is_void_v<T>, "cannot create a pointer to void");
 
     using observer_policy    = typename Policy::observer_policy;
     using control_block_type = basic_control_block<observer_policy>;

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -1570,8 +1570,8 @@ public:
 /**
  * \brief Perform a `static_cast` for an @ref basic_observable_ptr.
  * \param ptr The pointer to cast
- * \note Ownership will be transfered to the returned pointer.
-          If the input pointer is null, the output pointer will also be null.
+ * \note Ownership will be transferred to the returned pointer.
+ * If the input pointer is null, the output pointer will also be null.
  */
 template<typename U, typename T, typename D, typename P>
 basic_observable_ptr<U, D, P> static_pointer_cast(basic_observable_ptr<T, D, P>&& ptr) {
@@ -1582,7 +1582,7 @@ basic_observable_ptr<U, D, P> static_pointer_cast(basic_observable_ptr<T, D, P>&
  * \brief Perform a `static_cast` for a @ref basic_observer_ptr.
  * \param ptr The pointer to cast
  * \note A new observer is returned, the input observer is not modified.
-          If the input pointer is null, the output pointer will also be null.
+ * If the input pointer is null, the output pointer will also be null.
  */
 template<typename U, typename T, typename Policy>
 basic_observer_ptr<U, Policy> static_pointer_cast(const basic_observer_ptr<T, Policy>& ptr) {
@@ -1594,7 +1594,7 @@ basic_observer_ptr<U, Policy> static_pointer_cast(const basic_observer_ptr<T, Po
  * \brief Perform a `static_cast` for a @ref basic_observer_ptr.
  * \param ptr The pointer to cast
  * \note A new observer is returned, the input observer is set to null.
-          If the input pointer is null, the output pointer will also be null.
+ * If the input pointer is null, the output pointer will also be null.
  */
 template<typename U, typename T, typename Policy>
 basic_observer_ptr<U, Policy> static_pointer_cast(basic_observer_ptr<T, Policy>&& ptr) {
@@ -1605,8 +1605,8 @@ basic_observer_ptr<U, Policy> static_pointer_cast(basic_observer_ptr<T, Policy>&
 /**
  * \brief Perform a `const_cast` for an @ref basic_observable_ptr.
  * \param ptr The pointer to cast
- * \note Ownership will be transfered to the returned pointer.
-          If the input pointer is null, the output pointer will also be null.
+ * \note Ownership will be transferred to the returned pointer.
+ * If the input pointer is null, the output pointer will also be null.
  */
 template<typename U, typename T, typename D, typename P>
 basic_observable_ptr<U, D, P> const_pointer_cast(basic_observable_ptr<T, D, P>&& ptr) {
@@ -1617,7 +1617,7 @@ basic_observable_ptr<U, D, P> const_pointer_cast(basic_observable_ptr<T, D, P>&&
  * \brief Perform a `const_cast` for a @ref basic_observer_ptr.
  * \param ptr The pointer to cast
  * \note A new observer is returned, the input observer is not modified.
-          If the input pointer is null, the output pointer will also be null.
+ * If the input pointer is null, the output pointer will also be null.
  */
 template<typename U, typename T, typename Policy>
 basic_observer_ptr<U, Policy> const_pointer_cast(const basic_observer_ptr<T, Policy>& ptr) {
@@ -1629,7 +1629,7 @@ basic_observer_ptr<U, Policy> const_pointer_cast(const basic_observer_ptr<T, Pol
  * \brief Perform a `const_cast` for a @ref basic_observer_ptr.
  * \param ptr The pointer to cast
  * \note A new observer is returned, the input observer is set to null.
-          If the input pointer is null, the output pointer will also be null.
+ * If the input pointer is null, the output pointer will also be null.
  */
 template<typename U, typename T, typename Policy>
 basic_observer_ptr<U, Policy> const_pointer_cast(basic_observer_ptr<T, Policy>&& ptr) {
@@ -1640,7 +1640,7 @@ basic_observer_ptr<U, Policy> const_pointer_cast(basic_observer_ptr<T, Policy>&&
 /**
  * \brief Perform a `dynamic_cast` for a @ref basic_observable_ptr.
  * \param ptr The pointer to cast
- * \note Ownership will be transfered to the returned pointer unless the cast
+ * \note Ownership will be transferred to the returned pointer unless the cast
  * fails, in which case ownership remains in the original pointer, std::bad_cast
  * is thrown, and no memory is leaked. If the input pointer is null,
  * the output pointer will also be null.
@@ -1659,8 +1659,7 @@ basic_observable_ptr<U, D, P> dynamic_pointer_cast(basic_observable_ptr<T, D, P>
  * \brief Perform a `dynamic_cast` for a @ref basic_observer_ptr.
  * \param ptr The pointer to cast
  * \note A new observer is returned, the input observer is not modified.
-          If the input pointer is null, or if the cast fails, the output pointer
-          will be null.
+ * If the input pointer is null, or if the cast fails, the output pointer will be null.
  */
 template<typename U, typename T, typename Policy>
 basic_observer_ptr<U, Policy> dynamic_pointer_cast(const basic_observer_ptr<T, Policy>& ptr) {
@@ -1672,8 +1671,7 @@ basic_observer_ptr<U, Policy> dynamic_pointer_cast(const basic_observer_ptr<T, P
  * \brief Perform a `dynamic_cast` for a @ref basic_observer_ptr.
  * \param ptr The pointer to cast
  * \note A new observer is returned, the input observer is set to null.
-          If the input pointer is null, or if the cast fails, the output pointer
-          will be null.
+ * If the input pointer is null, or if the cast fails, the output pointer will be null.
  */
 template<typename U, typename T, typename Policy>
 basic_observer_ptr<U, Policy> dynamic_pointer_cast(basic_observer_ptr<T, Policy>&& ptr) {
@@ -1747,7 +1745,7 @@ using observable_unique_ptr = basic_observable_ptr<T, Deleter, unique_policy>;
  * If you need to create an @ref observer_ptr from a `this` pointer,
  * consider making the object inheriting from @ref enable_observer_from_this_sealed.
  * Compared to @ref enable_observer_from_this_unique, this has some additional
- * limitations. Please consult the documenation for @ref enable_observer_from_this_sealed
+ * limitations. Please consult the documentation for @ref enable_observer_from_this_sealed
  * for more information.
  *
  * Other notable points (either limitations imposed by the current

--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -353,7 +353,8 @@ constexpr bool has_enable_observer_from_this =
 template<typename T, typename Deleter, typename Policy>
 class basic_observable_ptr final {
 public:
-    static_assert(!std::is_array_v<T>, "T[] is not supported");
+    static_assert(!std::is_reference_v<T>, "cannot create a pointer to a reference");
+    static_assert(!std::is_array_v<T>, "cannot create a pointer to an array");
 
     /// Policy for this smart pointer
     using policy = Policy;
@@ -920,7 +921,8 @@ bool operator!=(
 template<typename T, typename Policy>
 class basic_observer_ptr final {
 public:
-    static_assert(!std::is_array_v<T>, "T[] is not supported");
+    static_assert(!std::is_reference_v<T>, "cannot create a pointer to a reference");
+    static_assert(!std::is_array_v<T>, "cannot create a pointer to an array");
 
     /// Policy for the control block
     using observer_policy = Policy;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,17 +1,18 @@
-# set OS preprocessor defines
-if(CMAKE_SYSTEM_NAME MATCHES "Emscripten")
-    set(OUP_PLATFORM_WASM TRUE)
-    set(OUP_COMPILER_EMSCRIPTEN TRUE)
-elseif (APPLE)
-    set(OUP_PLATFORM_OSX TRUE)
-elseif (UNIX)
-    set(OUP_PLATFORM_LINUX TRUE)
-elseif (WIN32)
-    set(OUP_PLATFORM_WINDOWS TRUE)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        set(OUP_COMPILER_MSVC TRUE)
-    endif()
-endif()
+function(add_platform_definitions TARGET)
+  if(CMAKE_SYSTEM_NAME MATCHES "Emscripten")
+      target_compile_definitions(${TARGET} PRIVATE OUP_PLATFORM_WASM)
+      target_compile_definitions(${TARGET} PRIVATE OUP_COMPILER_EMSCRIPTEN)
+  elseif (APPLE)
+      target_compile_definitions(${TARGET} PRIVATE OUP_PLATFORM_OSX)
+  elseif (UNIX)
+      target_compile_definitions(${TARGET} PRIVATE OUP_PLATFORM_LINUX)
+  elseif (WIN32)
+      target_compile_definitions(${TARGET} PRIVATE OUP_PLATFORM_WINDOWS)
+      if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+          target_compile_definitions(${TARGET} PRIVATE OUP_COMPILER_MSVC)
+      endif()
+  endif()
+endfunction()
 
 include(FetchContent)
 
@@ -28,13 +29,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${Catch2_SOURCE_DIR}/extras")
 add_executable(oup_tests ${PROJECT_SOURCE_DIR}/tests/runtime_tests.cpp)
 target_link_libraries(oup_tests PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(oup_tests PRIVATE oup::oup)
-target_compile_definitions(oup_tests PRIVATE
-  OUP_PLATFORM_OSX
-  OUP_PLATFORM_WASM
-  OUP_PLATFORM_LINUX
-  OUP_PLATFORM_WINDOWS
-  OUP_COMPILER_MSVC
-  OUP_COMPILER_EMSCRIPTEN)
+add_platform_definitions(oup_tests)
 
 include(CTest)
 include(Catch)
@@ -79,9 +74,11 @@ message(STATUS "Running compile-time tests ended.")
 
 add_executable(oup_size_benchmark ${PROJECT_SOURCE_DIR}/tests/size_benchmark.cpp)
 target_link_libraries(oup_size_benchmark PRIVATE oup::oup)
+add_platform_definitions(oup_tests)
 
 add_executable(oup_speed_benchmark
   ${PROJECT_SOURCE_DIR}/tests/speed_benchmark.cpp
   ${PROJECT_SOURCE_DIR}/tests/speed_benchmark_utility.cpp
   ${PROJECT_SOURCE_DIR}/tests/speed_benchmark_utility2.cpp)
 target_link_libraries(oup_speed_benchmark PRIVATE oup::oup)
+add_platform_definitions(oup_tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,11 +74,11 @@ message(STATUS "Running compile-time tests ended.")
 
 add_executable(oup_size_benchmark ${PROJECT_SOURCE_DIR}/tests/size_benchmark.cpp)
 target_link_libraries(oup_size_benchmark PRIVATE oup::oup)
-add_platform_definitions(oup_tests)
+add_platform_definitions(oup_size_benchmark)
 
 add_executable(oup_speed_benchmark
   ${PROJECT_SOURCE_DIR}/tests/speed_benchmark.cpp
   ${PROJECT_SOURCE_DIR}/tests/speed_benchmark_utility.cpp
   ${PROJECT_SOURCE_DIR}/tests/speed_benchmark_utility2.cpp)
 target_link_libraries(oup_speed_benchmark PRIVATE oup::oup)
-add_platform_definitions(oup_tests)
+add_platform_definitions(oup_speed_benchmark)

--- a/tests/memory_tracker.hpp
+++ b/tests/memory_tracker.hpp
@@ -27,7 +27,7 @@ void* allocate(std::size_t size, bool array, std::align_val_t align) {
     if (align == std::align_val_t{0}) {
         p = std::malloc(size);
     } else {
-#    if defined(OUP_PLATFORM_WINDOWS) && OUP_PLATFORM_WINDOWS
+#    if defined(OUP_PLATFORM_WINDOWS)
         p = _aligned_malloc(size, static_cast<std::size_t>(align));
 #    else
         p = std::aligned_alloc(static_cast<std::size_t>(align), size);
@@ -81,7 +81,7 @@ void deallocate(void* p, bool array, std::align_val_t align [[maybe_unused]]) {
     if (align == std::align_val_t{0}) {
         std::free(p);
     } else {
-#    if defined(OUP_PLATFORM_WINDOWS) && OUP_PLATFORM_WINDOWS
+#    if defined(OUP_PLATFORM_WINDOWS)
         _aligned_free(p);
 #    else
         std::free(p);

--- a/tests/memory_tracker.hpp
+++ b/tests/memory_tracker.hpp
@@ -1,0 +1,145 @@
+#include <algorithm>
+#include <cstdlib>
+
+// Allocation tracker, to catch memory leaks and double delete
+constexpr std::size_t max_allocations = 20'000;
+void*                 allocations[max_allocations];
+void*                 allocations_array[max_allocations];
+std::size_t           allocations_bytes[max_allocations];
+std::size_t           num_allocations               = 0u;
+std::size_t           size_allocations              = 0u;
+std::size_t           double_delete                 = 0u;
+bool                  memory_tracking               = false;
+bool                  force_next_allocation_failure = false;
+
+#if defined(CHECK_MEMORY_LEAKS) && CHECK_MEMORY_LEAKS
+void* allocate(std::size_t size, bool array, std::align_val_t align) {
+    if (memory_tracking && num_allocations == max_allocations) {
+        throw std::bad_alloc();
+    }
+
+    if (force_next_allocation_failure) {
+        force_next_allocation_failure = false;
+        throw std::bad_alloc();
+    }
+
+    void* p = nullptr;
+    if (align == std::align_val_t{0}) {
+        p = std::malloc(size);
+    } else {
+#    if defined(OUP_PLATFORM_WINDOWS) && OUP_PLATFORM_WINDOWS
+        p = _aligned_malloc(size, static_cast<std::size_t>(align));
+#    else
+        p = std::aligned_alloc(static_cast<std::size_t>(align), size);
+#    endif
+    }
+
+    if (!p) {
+        throw std::bad_alloc();
+    }
+
+    if (memory_tracking) {
+        if (array) {
+            allocations_array[num_allocations] = p;
+        } else {
+            allocations[num_allocations] = p;
+        }
+
+        allocations_bytes[num_allocations] = size;
+
+        ++num_allocations;
+        size_allocations += size;
+    }
+
+    return p;
+}
+
+void deallocate(void* p, bool array, std::align_val_t align [[maybe_unused]]) {
+    if (p == nullptr) {
+        return;
+    }
+
+    if (memory_tracking) {
+        bool   found            = false;
+        void** allocations_type = array ? allocations_array : allocations;
+        for (std::size_t i = 0; i < num_allocations; ++i) {
+            if (allocations_type[i] == p) {
+                std::swap(allocations_type[i], allocations_type[num_allocations - 1]);
+                std::swap(allocations_bytes[i], allocations_bytes[num_allocations - 1]);
+                --num_allocations;
+                size_allocations -= allocations_bytes[num_allocations - 1];
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            ++double_delete;
+        }
+    }
+
+    if (align == std::align_val_t{0}) {
+        std::free(p);
+    } else {
+#    if defined(OUP_PLATFORM_WINDOWS) && OUP_PLATFORM_WINDOWS
+        _aligned_free(p);
+#    else
+        std::free(p);
+#    endif
+    }
+}
+
+void* operator new(std::size_t size) {
+    return allocate(size, false, std::align_val_t{0});
+}
+
+void* operator new[](size_t size) {
+    return allocate(size, true, std::align_val_t{0});
+}
+
+void* operator new(std::size_t size, std::align_val_t al) {
+    return allocate(size, false, al);
+}
+
+void* operator new[](size_t size, std::align_val_t al) {
+    return allocate(size, true, al);
+}
+
+void operator delete(void* p) noexcept {
+    deallocate(p, false, std::align_val_t{0});
+}
+
+void operator delete[](void* p) noexcept {
+    deallocate(p, true, std::align_val_t{0});
+}
+
+void operator delete(void* p, std::align_val_t al) noexcept {
+    deallocate(p, false, al);
+}
+
+void operator delete[](void* p, std::align_val_t al) noexcept {
+    deallocate(p, true, al);
+}
+#endif
+
+struct memory_tracker {
+    std::size_t initial_allocations;
+    std::size_t initial_double_delete;
+
+    memory_tracker() noexcept :
+        initial_allocations(num_allocations), initial_double_delete(double_delete) {
+        memory_tracking = true;
+    }
+
+    ~memory_tracker() noexcept {
+        memory_tracking = false;
+    }
+
+    std::size_t leaks() const {
+        return num_allocations - initial_allocations;
+    }
+
+    std::size_t double_del() const {
+        return double_delete - initial_double_delete;
+    }
+};

--- a/tests/memory_tracker.hpp
+++ b/tests/memory_tracker.hpp
@@ -12,7 +12,7 @@ std::size_t           double_delete                 = 0u;
 bool                  memory_tracking               = false;
 bool                  force_next_allocation_failure = false;
 
-#if defined(CHECK_MEMORY_LEAKS) && CHECK_MEMORY_LEAKS
+#if defined(CHECK_MEMORY_LEAKS)
 void* allocate(std::size_t size, bool array, std::align_val_t align) {
     if (memory_tracking && num_allocations == max_allocations) {
         throw std::bad_alloc();
@@ -27,9 +27,9 @@ void* allocate(std::size_t size, bool array, std::align_val_t align) {
     if (align == std::align_val_t{0}) {
         p = std::malloc(size);
     } else {
-#    if defined(OUP_PLATFORM_WINDOWS)
+#    if defined(OUP_COMPILER_MSVC)
         p = _aligned_malloc(size, static_cast<std::size_t>(align));
-#    elif defined(OUP_PLATFORM_EMSCRIPTEN)
+#    elif defined(OUP_COMPILER_EMSCRIPTEN)
         p = aligned_alloc(static_cast<std::size_t>(align), size);
 #    else
         p = std::aligned_alloc(static_cast<std::size_t>(align), size);
@@ -83,7 +83,7 @@ void deallocate(void* p, bool array, std::align_val_t align [[maybe_unused]]) {
     if (align == std::align_val_t{0}) {
         std::free(p);
     } else {
-#    if defined(OUP_PLATFORM_WINDOWS)
+#    if defined(OUP_COMPILER_MSVC)
         _aligned_free(p);
 #    else
         std::free(p);

--- a/tests/memory_tracker.hpp
+++ b/tests/memory_tracker.hpp
@@ -29,6 +29,8 @@ void* allocate(std::size_t size, bool array, std::align_val_t align) {
     } else {
 #    if defined(OUP_PLATFORM_WINDOWS)
         p = _aligned_malloc(size, static_cast<std::size_t>(align));
+#    elif defined(OUP_PLATFORM_EMSCRIPTEN)
+        p = aligned_alloc(static_cast<std::size_t>(align), size);
 #    else
         p = std::aligned_alloc(static_cast<std::size_t>(align), size);
 #    endif

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 // Allocation tracker, to catch memory leaks and double delete
-constexpr std::size_t max_allocations = 200'000;
+constexpr std::size_t max_allocations = 20'000;
 void*                 allocations[max_allocations];
 void*                 allocations_array[max_allocations];
 std::size_t           num_allocations          = 0u;
@@ -45,6 +45,10 @@ void* allocate(std::size_t size, bool array) {
 }
 
 void deallocate(void* p, bool array) {
+    if (p == nullptr) {
+        return;
+    }
+
     if (memory_tracking) {
         bool   found            = false;
         void** allocations_type = array ? allocations_array : allocations;

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -3494,6 +3494,49 @@ TEST_CASE("observer from this maybe no block reset to new", "[observer_from_this
     REQUIRE(mem_track.double_del() == 0u);
 }
 
+TEST_CASE("observer from this maybe no block reset to new after release", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        auto* raw_ptr = new test_object_observer_from_this_maybe_no_block_unique;
+
+        test_ptr_from_this_maybe_no_block        ptr{raw_ptr};
+        const test_ptr_from_this_maybe_no_block& cptr = ptr;
+
+        test_optr_from_this_maybe_no_block_unique       optr_from_this = ptr->observer_from_this();
+        test_optr_from_this_const_maybe_no_block_unique optr_from_this_const =
+            cptr->observer_from_this();
+
+        ptr.release();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == raw_ptr);
+        REQUIRE(optr_from_this_const.get() == raw_ptr);
+
+        ptr.reset(raw_ptr);
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == ptr.get());
+        REQUIRE(optr_from_this_const.get() == ptr.get());
+
+        ptr.reset();
+
+        REQUIRE(instances == 0);
+        REQUIRE(optr_from_this.expired() == true);
+        REQUIRE(optr_from_this_const.expired() == true);
+        REQUIRE(optr_from_this.get() == nullptr);
+        REQUIRE(optr_from_this_const.get() == nullptr);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
 TEST_CASE("observer from this maybe no block reset to new bad alloc", "[observer_from_this]") {
     memory_tracker mem_track;
 

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -9,9 +9,10 @@
 constexpr std::size_t max_allocations = 20'000;
 void*                 allocations[max_allocations];
 void*                 allocations_array[max_allocations];
-std::size_t           num_allocations = 0u;
-std::size_t           double_delete   = 0u;
-bool                  memory_tracking = false;
+std::size_t           num_allocations          = 0u;
+std::size_t           double_delete            = 0u;
+bool                  memory_tracking          = false;
+bool                  force_allocation_failure = false;
 
 #if defined(OUP_PLATFORM_OSX)
 // Getting weird errors on MacOS when overriding operator new and delete,
@@ -24,6 +25,10 @@ bool                  memory_tracking = false;
 #if defined(CHECK_MEMORY_LEAKS) && CHECK_MEMORY_LEAKS
 void* allocate(std::size_t size, bool array) {
     if (memory_tracking && num_allocations == max_allocations) {
+        throw std::bad_alloc();
+    }
+
+    if (force_allocation_failure) {
         throw std::bad_alloc();
     }
 
@@ -277,6 +282,24 @@ TEST_CASE("owner acquiring constructor", "[owner_construction]") {
     REQUIRE(mem_track.double_del() == 0u);
 }
 
+TEST_CASE("owner acquiring constructor bad alloc", "[owner_construction]") {
+    memory_tracker mem_track;
+
+    {
+        test_object* raw_ptr = new test_object;
+        try {
+            force_allocation_failure = true;
+            test_ptr{raw_ptr};
+        } catch (...) {
+        }
+        force_allocation_failure = false;
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
 TEST_CASE("owner acquiring constructor with deleter", "[owner_construction]") {
     memory_tracker mem_track;
 
@@ -290,6 +313,24 @@ TEST_CASE("owner acquiring constructor with deleter", "[owner_construction]") {
 
     REQUIRE(instances == 0);
     REQUIRE(instances_deleter == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("owner acquiring constructor with deleter bad alloc", "[owner_construction]") {
+    memory_tracker mem_track;
+
+    {
+        test_object* raw_ptr = new test_object;
+        try {
+            force_allocation_failure = true;
+            test_ptr_with_deleter{raw_ptr, test_deleter{42}};
+        } catch (...) {
+        }
+        force_allocation_failure = false;
+    }
+
+    REQUIRE(instances == 0);
     REQUIRE(mem_track.leaks() == 0u);
     REQUIRE(mem_track.double_del() == 0u);
 }
@@ -1271,6 +1312,28 @@ TEST_CASE("owner reset to new", "[owner_utility]") {
         ptr.reset(new test_object);
         REQUIRE(instances == 1);
         REQUIRE(ptr.get() != nullptr);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("owner reset to new bad alloc", "[owner_utility]") {
+    memory_tracker mem_track;
+
+    {
+        test_object* raw_ptr1 = new test_object;
+        test_object* raw_ptr2 = new test_object;
+        test_ptr     ptr(raw_ptr1);
+        try {
+            force_allocation_failure = true;
+            ptr.reset(raw_ptr2);
+        } catch (...) {
+        }
+        force_allocation_failure = false;
+        REQUIRE(instances == 1);
+        REQUIRE(ptr.get() == raw_ptr1);
     }
 
     REQUIRE(instances == 0);

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -1,5 +1,5 @@
 #include "tests_common.hpp"
-#define CHECK_MEMORY_LEAKS 1
+#define CHECK_MEMORY_LEAKS
 #include "memory_tracker.hpp"
 
 #include <catch2/catch_test_macros.hpp>

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -3286,7 +3286,7 @@ TEST_CASE("pointers in vector", "[system_tests]") {
     REQUIRE(mem_track.double_del() == 0u);
 }
 
-TEST_CASE("observer from this", "[observer_from_this]") {
+TEST_CASE("observer from this unique", "[observer_from_this]") {
     memory_tracker mem_track;
 
     {

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 // Allocation tracker, to catch memory leaks and double delete
-constexpr std::size_t max_allocations = 20'000;
+constexpr std::size_t max_allocations = 200'000;
 void*                 allocations[max_allocations];
 void*                 allocations_array[max_allocations];
 std::size_t           num_allocations          = 0u;
@@ -14,13 +14,7 @@ std::size_t           double_delete            = 0u;
 bool                  memory_tracking          = false;
 bool                  force_allocation_failure = false;
 
-#if defined(OUP_PLATFORM_OSX)
-// Getting weird errors on MacOS when overriding operator new and delete,
-// so disable the memory leak checking for this platform.
-#    define CHECK_MEMORY_LEAKS 0
-#else
-#    define CHECK_MEMORY_LEAKS 1
-#endif
+#define CHECK_MEMORY_LEAKS 1
 
 #if defined(CHECK_MEMORY_LEAKS) && CHECK_MEMORY_LEAKS
 void* allocate(std::size_t size, bool array) {

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -3412,6 +3412,109 @@ TEST_CASE("observer from this non virtual unique", "[observer_from_this]") {
     REQUIRE(mem_track.double_del() == 0u);
 }
 
+TEST_CASE("observer from this maybe no block unique", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr_from_this_maybe_no_block ptr = oup::make_observable<
+            test_object_observer_from_this_maybe_no_block_unique, unique_maybe_no_block_policy>();
+        const test_ptr_from_this_maybe_no_block& cptr = ptr;
+
+        test_optr_from_this_maybe_no_block_unique       optr_from_this = ptr->observer_from_this();
+        test_optr_from_this_const_maybe_no_block_unique optr_from_this_const =
+            cptr->observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == ptr.get());
+        REQUIRE(optr_from_this_const.get() == ptr.get());
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer from this maybe no block acquire", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        test_ptr_from_this_maybe_no_block ptr{
+            new test_object_observer_from_this_maybe_no_block_unique};
+        const test_ptr_from_this_maybe_no_block& cptr = ptr;
+
+        test_optr_from_this_maybe_no_block_unique       optr_from_this = ptr->observer_from_this();
+        test_optr_from_this_const_maybe_no_block_unique optr_from_this_const =
+            cptr->observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == ptr.get());
+        REQUIRE(optr_from_this_const.get() == ptr.get());
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer from this maybe no block reset to new", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        auto* raw_ptr1 = new test_object_observer_from_this_maybe_no_block_unique;
+        auto* raw_ptr2 = new test_object_observer_from_this_maybe_no_block_unique;
+
+        test_ptr_from_this_maybe_no_block        ptr{raw_ptr1};
+        const test_ptr_from_this_maybe_no_block& cptr = ptr;
+
+        ptr.reset(raw_ptr2);
+
+        test_optr_from_this_maybe_no_block_unique       optr_from_this = ptr->observer_from_this();
+        test_optr_from_this_const_maybe_no_block_unique optr_from_this_const =
+            cptr->observer_from_this();
+
+        REQUIRE(instances == 1);
+        REQUIRE(optr_from_this.expired() == false);
+        REQUIRE(optr_from_this_const.expired() == false);
+        REQUIRE(optr_from_this.get() == ptr.get());
+        REQUIRE(optr_from_this.get() == raw_ptr2);
+        REQUIRE(optr_from_this_const.get() == ptr.get());
+        REQUIRE(optr_from_this_const.get() == raw_ptr2);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
+TEST_CASE("observer from this maybe no block reset to new bad alloc", "[observer_from_this]") {
+    memory_tracker mem_track;
+
+    {
+        auto* raw_ptr1 = new test_object_observer_from_this_maybe_no_block_unique;
+        auto* raw_ptr2 = new test_object_observer_from_this_maybe_no_block_unique;
+
+        test_ptr_from_this_maybe_no_block ptr{raw_ptr1};
+
+        try {
+            force_allocation_failure = true;
+            ptr.reset(raw_ptr2);
+        } catch (...) {
+        }
+
+        force_allocation_failure = false;
+        REQUIRE(instances == 1);
+        REQUIRE(ptr.get() == raw_ptr1);
+    }
+
+    REQUIRE(instances == 0);
+    REQUIRE(mem_track.leaks() == 0u);
+    REQUIRE(mem_track.double_del() == 0u);
+}
+
 TEST_CASE("observer from this virtual sealed", "[observer_from_this]") {
     memory_tracker mem_track;
 

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -14,6 +14,20 @@ std::size_t           double_delete                 = 0u;
 bool                  memory_tracking               = false;
 bool                  force_next_allocation_failure = false;
 
+// Replace Catch2's REQUIRE_THROWS_AS, which allocates on Windows;
+// this confuses our memory leak checks.
+#undef REQUIRE_THROWS_AS
+#define REQUIRE_THROWS_AS(EXPRESSION, EXCEPTION)                                                   \
+    do {                                                                                           \
+        try {                                                                                      \
+            EXPRESSION;                                                                            \
+            FAIL("no exception thrown");                                                           \
+        } catch (const EXCEPTION&) {                                                               \
+        } catch (...) {                                                                            \
+            FAIL("unexpected exception thrown");                                                   \
+        }                                                                                          \
+    } while (0)
+
 #define CHECK_MEMORY_LEAKS 1
 
 #if defined(CHECK_MEMORY_LEAKS) && CHECK_MEMORY_LEAKS

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -14,6 +14,8 @@
             EXPRESSION;                                                                            \
             FAIL("no exception thrown");                                                           \
         } catch (const EXCEPTION&) {                                                               \
+        } catch (const std::exception& e) {                                                        \
+            FAIL(e.what());                                                                        \
         } catch (...) {                                                                            \
             FAIL("unexpected exception thrown");                                                   \
         }                                                                                          \

--- a/tests/size_benchmark.cpp
+++ b/tests/size_benchmark.cpp
@@ -1,132 +1,96 @@
+#define CHECK_MEMORY_LEAKS 1
+#include "memory_tracker.hpp"
+
 #include <iostream>
 #include <memory>
 #include <oup/observable_unique_ptr.hpp>
-
-// Allocation tracker, to catch memory leaks and double delete
-constexpr std::size_t max_allocations = 20'000;
-void*                 allocations[max_allocations];
-std::size_t           allocations_bytes[max_allocations];
-std::size_t           num_allocations  = 0u;
-std::size_t           size_allocations = 0u;
-std::size_t           double_delete    = 0u;
-bool                  memory_tracking  = false;
-
-// NB: getting weird errors on MacOS when doing this
-#if !defined(__APPLE__)
-void* operator new(size_t size) {
-    if (memory_tracking && num_allocations == max_allocations) {
-        throw std::bad_alloc();
-    }
-
-    void* p = std::malloc(size);
-    if (!p) {
-        throw std::bad_alloc();
-    }
-
-    if (memory_tracking) {
-        allocations[num_allocations]       = p;
-        allocations_bytes[num_allocations] = size;
-        ++num_allocations;
-        size_allocations += size;
-    }
-
-    return p;
-}
-
-void operator delete(void* p) noexcept {
-    if (memory_tracking) {
-        bool found = false;
-        for (std::size_t i = 0; i < num_allocations; ++i) {
-            if (allocations[i] == p) {
-                std::swap(allocations[i], allocations[num_allocations - 1]);
-                std::swap(allocations_bytes[i], allocations_bytes[num_allocations - 1]);
-                --num_allocations;
-                size_allocations -= allocations_bytes[num_allocations - 1];
-                found = true;
-                break;
-            }
-        }
-
-        if (!found) {
-            ++double_delete;
-        }
-    }
-
-    std::free(p);
-}
-#endif
-
-struct memory_tracker {
-    std::size_t initial_allocations;
-    std::size_t initial_double_delete;
-
-    memory_tracker() noexcept :
-        initial_allocations(num_allocations), initial_double_delete(double_delete) {
-        memory_tracking = true;
-    }
-
-    ~memory_tracker() noexcept {
-        memory_tracking = false;
-    }
-
-    std::size_t leaks() const {
-        return num_allocations - initial_allocations;
-    }
-    std::size_t double_del() const {
-        return double_delete - initial_double_delete;
-    }
-};
 
 int main() {
     memory_tracking        = true;
     std::size_t init_alloc = 0u;
 
+    using test_type = int;
+
     std::size_t unique_size = 0u;
     init_alloc              = size_allocations;
     {
-        std::unique_ptr<int> ptr(new int);
-        unique_size = size_allocations - sizeof(int) - init_alloc;
+        std::unique_ptr<test_type> ptr(new test_type);
+        unique_size = size_allocations - sizeof(test_type) - init_alloc;
         std::cout << "unique_ptr size: " << sizeof(ptr) << ", " << unique_size << std::endl;
     }
 
     init_alloc = size_allocations;
     {
-        std::unique_ptr<int> ptr(new int);
-        int*                 wptr = ptr.get();
+        std::unique_ptr<test_type> ptr(new test_type);
+        test_type*                 wptr = ptr.get();
         std::cout << "raw pointer size: " << sizeof(wptr) << ", "
-                  << size_allocations - sizeof(int) - init_alloc - unique_size << std::endl;
+                  << size_allocations - sizeof(test_type) - init_alloc - unique_size << std::endl;
     }
 
     std::size_t shared_size = 0u;
     init_alloc              = size_allocations;
     {
-        std::shared_ptr<int> ptr(new int);
-        shared_size = size_allocations - sizeof(int) - init_alloc;
+        std::shared_ptr<test_type> ptr(new test_type);
+        shared_size = size_allocations - sizeof(test_type) - init_alloc;
         std::cout << "shared_ptr size: " << sizeof(ptr) << ", " << shared_size << std::endl;
     }
 
     init_alloc = size_allocations;
     {
-        std::shared_ptr<int> ptr(new int);
-        std::weak_ptr<int>   wptr(ptr);
+        std::shared_ptr<test_type> ptr(new test_type);
+        std::weak_ptr<test_type>   wptr(ptr);
         std::cout << "weak_ptr size: " << sizeof(wptr) << ", "
-                  << size_allocations - sizeof(int) - init_alloc - shared_size << std::endl;
+                  << size_allocations - sizeof(test_type) - init_alloc - shared_size << std::endl;
+    }
+
+    init_alloc = size_allocations;
+    {
+        std::shared_ptr<test_type> ptr = std::make_shared<test_type>();
+        shared_size                    = size_allocations - sizeof(test_type) - init_alloc;
+        std::cout << "shared_ptr size (make_shared): " << sizeof(ptr) << ", " << shared_size
+                  << std::endl;
+    }
+
+    init_alloc = size_allocations;
+    {
+        std::shared_ptr<test_type> ptr = std::make_shared<test_type>();
+        std::weak_ptr<test_type>   wptr(ptr);
+        std::cout << "weak_ptr size (make_shared): " << sizeof(wptr) << ", "
+                  << size_allocations - sizeof(test_type) - init_alloc - shared_size << std::endl;
     }
 
     std::size_t observable_size = 0u;
     init_alloc                  = size_allocations;
     {
-        oup::observable_unique_ptr<int> ptr(new int);
-        observable_size = size_allocations - sizeof(int) - init_alloc;
+        oup::observable_unique_ptr<test_type> ptr(new test_type);
+        observable_size = size_allocations - sizeof(test_type) - init_alloc;
         std::cout << "observable_unique_ptr size: " << sizeof(ptr) << ", " << observable_size
                   << std::endl;
     }
 
     init_alloc = size_allocations;
     {
-        oup::observable_unique_ptr<int> ptr(new int);
-        oup::observer_ptr<int>          wptr(ptr);
-        std::cout << "observer_ptr size: " << sizeof(wptr) << ", "
-                  << size_allocations - sizeof(int) - init_alloc - observable_size << std::endl;
+        oup::observable_unique_ptr<test_type> ptr(new test_type);
+        oup::observer_ptr<test_type>          wptr(ptr);
+        std::cout << "observer_ptr size (unique): " << sizeof(wptr) << ", "
+                  << size_allocations - sizeof(test_type) - init_alloc - observable_size
+                  << std::endl;
+    }
+
+    init_alloc = size_allocations;
+    {
+        oup::observable_sealed_ptr<test_type> ptr = oup::make_observable_sealed<test_type>();
+        observable_size = size_allocations - sizeof(test_type) - init_alloc;
+        std::cout << "observable_sealed_ptr size: " << sizeof(ptr) << ", " << observable_size
+                  << std::endl;
+    }
+
+    init_alloc = size_allocations;
+    {
+        oup::observable_sealed_ptr<test_type> ptr = oup::make_observable_sealed<test_type>();
+        oup::observer_ptr<test_type>          wptr(ptr);
+        std::cout << "observer_ptr size (sealed): " << sizeof(wptr) << ", "
+                  << size_allocations - sizeof(test_type) - init_alloc - observable_size
+                  << std::endl;
     }
 }

--- a/tests/size_benchmark.cpp
+++ b/tests/size_benchmark.cpp
@@ -1,4 +1,4 @@
-#define CHECK_MEMORY_LEAKS 1
+#define CHECK_MEMORY_LEAKS
 #include "memory_tracker.hpp"
 
 #include <iostream>

--- a/tests/speed_benchmark.cpp
+++ b/tests/speed_benchmark.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iomanip>
+#include <sstream>
 #include <unordered_map>
 #include <vector>
 

--- a/tests/tests_common.hpp
+++ b/tests/tests_common.hpp
@@ -81,6 +81,14 @@ struct unique_non_virtual_policy {
     using observer_policy                                      = oup::default_observer_policy;
 };
 
+struct unique_maybe_no_block_policy {
+    static constexpr bool is_sealed                            = false;
+    static constexpr bool allow_eoft_in_constructor            = false;
+    static constexpr bool allow_eoft_multiple_inheritance      = true;
+    static constexpr bool eoft_constructor_takes_control_block = false;
+    using observer_policy                                      = oup::default_observer_policy;
+};
+
 struct test_object_observer_from_this_virtual_sealed :
     public test_object,
     public oup::basic_enable_observer_from_this<
@@ -98,6 +106,12 @@ struct test_object_observer_from_this_non_virtual_unique :
             test_object_observer_from_this_non_virtual_unique,
             unique_non_virtual_policy>(block) {}
 };
+
+struct test_object_observer_from_this_maybe_no_block_unique :
+    public test_object,
+    public oup::basic_enable_observer_from_this<
+        test_object_observer_from_this_maybe_no_block_unique,
+        unique_maybe_no_block_policy> {};
 
 struct test_object_thrower_observer_from_this_non_virtual_unique :
     public oup::basic_enable_observer_from_this<
@@ -275,6 +289,11 @@ using test_ptr_from_this_non_virtual = oup::basic_observable_ptr<
     oup::default_delete,
     unique_non_virtual_policy>;
 
+using test_ptr_from_this_maybe_no_block = oup::basic_observable_ptr<
+    test_object_observer_from_this_maybe_no_block_unique,
+    oup::default_delete,
+    unique_maybe_no_block_policy>;
+
 using test_sptr_from_this_virtual = oup::basic_observable_ptr<
     test_object_observer_from_this_virtual_sealed,
     oup::placement_delete,
@@ -323,6 +342,10 @@ using test_optr_from_this_non_virtual_unique =
     oup::observer_ptr<test_object_observer_from_this_non_virtual_unique>;
 using test_optr_from_this_const_non_virtual_unique =
     oup::observer_ptr<const test_object_observer_from_this_non_virtual_unique>;
+using test_optr_from_this_maybe_no_block_unique =
+    oup::observer_ptr<test_object_observer_from_this_maybe_no_block_unique>;
+using test_optr_from_this_const_maybe_no_block_unique =
+    oup::observer_ptr<const test_object_observer_from_this_maybe_no_block_unique>;
 using test_optr_from_this_virtual_sealed =
     oup::observer_ptr<test_object_observer_from_this_virtual_sealed>;
 using test_optr_from_this_const_virtual_sealed =


### PR DESCRIPTION
List of changes in this PR:
 - Fixed `enable_observer_from_this*` with policies that do not guarantee the existence of a block (i.e., custom policies that are not the default `unique` or `sealed`).
 - Fixed leaks for non-sealed pointers, when allocation of the control block fails in the constructor or in `reset()`.
 - Fixed `make_observable*()` not aware of alignment constraints.
 - Added early `static_assert` to catch misuse and generate clearer error messages.
 - Various typos fixed, and documentation improved.
 - Speed benchmarks updated.
 - Size benchmarks updated.