### PR TITLE
Clean up header inclusion in tests

### DIFF
--- a/include/oup/observable_unique_ptr.hpp
+++ b/include/oup/observable_unique_ptr.hpp
@@ -41,11 +41,11 @@ class ptr_and_deleter : private Deleter {
 public:
     explicit ptr_and_deleter(Deleter d, T* ptr) : Deleter(std::move(d)), data(ptr) {}
 
-    ptr_and_deleter()                       = default;
-    ptr_and_deleter(const ptr_and_deleter&) = default;
-    ptr_and_deleter(ptr_and_deleter&&)      = default;
+    ptr_and_deleter()                                  = default;
+    ptr_and_deleter(const ptr_and_deleter&)            = default;
+    ptr_and_deleter(ptr_and_deleter&&)                 = default;
     ptr_and_deleter& operator=(const ptr_and_deleter&) = default;
-    ptr_and_deleter& operator=(ptr_and_deleter&&) = default;
+    ptr_and_deleter& operator=(ptr_and_deleter&&)      = default;
 
     T*& pointer() {
         return data;
@@ -239,11 +239,11 @@ class basic_control_block final {
 
     control_block_storage_type storage = 1;
 
-    basic_control_block() noexcept                  = default;
-    basic_control_block(const basic_control_block&) = delete;
-    basic_control_block(basic_control_block&&)      = delete;
+    basic_control_block() noexcept                             = default;
+    basic_control_block(const basic_control_block&)            = delete;
+    basic_control_block(basic_control_block&&)                 = delete;
     basic_control_block& operator=(const basic_control_block&) = delete;
-    basic_control_block& operator=(basic_control_block&&) = delete;
+    basic_control_block& operator=(basic_control_block&&)      = delete;
 
     void push_ref() noexcept {
         ++storage;
@@ -296,10 +296,10 @@ struct enable_observer_from_this_base {
         block.push_ref();
     }
 
-    enable_observer_from_this_base(const enable_observer_from_this_base&) = delete;
-    enable_observer_from_this_base(enable_observer_from_this_base&&)      = delete;
+    enable_observer_from_this_base(const enable_observer_from_this_base&)            = delete;
+    enable_observer_from_this_base(enable_observer_from_this_base&&)                 = delete;
     enable_observer_from_this_base& operator=(const enable_observer_from_this_base&) = delete;
-    enable_observer_from_this_base& operator=(enable_observer_from_this_base&&) = delete;
+    enable_observer_from_this_base& operator=(enable_observer_from_this_base&&)      = delete;
 
     virtual ~enable_observer_from_this_base() noexcept {
         if (this_control_block) {
@@ -701,7 +701,7 @@ public:
     }
 
     // Non-copyable
-    basic_observable_ptr(const basic_observable_ptr&) = delete;
+    basic_observable_ptr(const basic_observable_ptr&)            = delete;
     basic_observable_ptr& operator=(const basic_observable_ptr&) = delete;
 
     /**

--- a/tests/memory_tracker.cpp
+++ b/tests/memory_tracker.cpp
@@ -1,6 +1,8 @@
 #include "memory_tracker.hpp"
 
+#include <algorithm>
 #include <cstdio>
+#include <stdexcept>
 
 void*       allocations[max_allocations];
 void*       allocations_array[max_allocations];

--- a/tests/memory_tracker.hpp
+++ b/tests/memory_tracker.hpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <cstdlib>
 
 // Allocation tracker, to catch memory leaks and double delete

--- a/tests/memory_tracker.hpp
+++ b/tests/memory_tracker.hpp
@@ -1,4 +1,5 @@
 #include <cstdlib>
+#include <new>
 
 // Allocation tracker, to catch memory leaks and double delete
 constexpr std::size_t max_allocations = 20'000;

--- a/tests/runtime_tests_lifetime.cpp
+++ b/tests/runtime_tests_lifetime.cpp
@@ -2,6 +2,7 @@
 #include "testing.hpp"
 #include "tests_common.hpp"
 
+#include <algorithm>
 #include <vector>
 
 TEMPLATE_LIST_TEST_CASE("observer expiring scope", "[lifetime][owner][observer]", owner_types) {

--- a/tests/speed_benchmark_utility.cpp
+++ b/tests/speed_benchmark_utility.cpp
@@ -37,7 +37,7 @@ template void use_object<std::weak_ptr<std::array<int, 65'536>>>(
 template void
 use_object<oup::observable_unique_ptr<int>>(oup::observable_unique_ptr<int>&) noexcept;
 template void
-              use_object<oup::observable_unique_ptr<float>>(oup::observable_unique_ptr<float>&) noexcept;
+use_object<oup::observable_unique_ptr<float>>(oup::observable_unique_ptr<float>&) noexcept;
 template void use_object<oup::observable_unique_ptr<std::string>>(
     oup::observable_unique_ptr<std::string>&) noexcept;
 template void use_object<oup::observable_unique_ptr<std::array<int, 65'536>>>(
@@ -46,7 +46,7 @@ template void use_object<oup::observable_unique_ptr<std::array<int, 65'536>>>(
 template void
 use_object<oup::observable_sealed_ptr<int>>(oup::observable_sealed_ptr<int>&) noexcept;
 template void
-              use_object<oup::observable_sealed_ptr<float>>(oup::observable_sealed_ptr<float>&) noexcept;
+use_object<oup::observable_sealed_ptr<float>>(oup::observable_sealed_ptr<float>&) noexcept;
 template void use_object<oup::observable_sealed_ptr<std::string>>(
     oup::observable_sealed_ptr<std::string>&) noexcept;
 template void use_object<oup::observable_sealed_ptr<std::array<int, 65'536>>>(

--- a/tests/tests_common.hpp
+++ b/tests/tests_common.hpp
@@ -21,7 +21,7 @@ struct test_object {
     test_object(test_object&&)      = delete;
 
     test_object& operator=(const test_object&) = delete;
-    test_object& operator=(test_object&&) = delete;
+    test_object& operator=(test_object&&)      = delete;
 };
 
 struct test_object_derived : test_object {
@@ -353,7 +353,7 @@ struct test_deleter {
     ~test_deleter() noexcept;
 
     test_deleter& operator=(const test_deleter&) = default;
-    test_deleter& operator                       =(test_deleter&& source) noexcept;
+    test_deleter& operator=(test_deleter&& source) noexcept;
 
     void operator()(test_object* ptr) noexcept;
     void operator()(const test_object* ptr) noexcept;
@@ -438,24 +438,24 @@ template<typename T>
 constexpr bool has_eoft_self_member = has_eoft<T> && !has_eoft_obs_member<T>;
 
 template<typename T>
-constexpr bool    eoft_constructor_takes_control_block =
-    has_eoft<T>&& get_policy<T>::eoft_constructor_takes_control_block;
+constexpr bool eoft_constructor_takes_control_block =
+    has_eoft<T> && get_policy<T>::eoft_constructor_takes_control_block;
 
 template<typename T>
-constexpr bool eoft_allocates = has_eoft<T>&&
-               oup::policy_queries<get_policy<T>>::eoft_constructor_allocates();
+constexpr bool eoft_allocates =
+    has_eoft<T> && oup::policy_queries<get_policy<T>>::eoft_constructor_allocates();
 
 template<typename T>
-constexpr bool eoft_always_has_block = has_eoft<T>&&
-               oup::policy_queries<get_policy<T>>::eoft_always_has_block();
+constexpr bool eoft_always_has_block =
+    has_eoft<T> && oup::policy_queries<get_policy<T>>::eoft_always_has_block();
 
 template<typename T>
 constexpr bool must_use_make_observable = is_sealed<T> || eoft_constructor_takes_control_block<T>;
 
 template<typename T>
-constexpr bool can_use_make_observable = (is_sealed<T> &&
-                                          std::is_same_v<get_deleter<T>, oup::placement_delete>) ||
-                                         std::is_same_v<get_deleter<T>, oup::default_delete>;
+constexpr bool can_use_make_observable =
+    (is_sealed<T> && std::is_same_v<get_deleter<T>, oup::placement_delete>) ||
+    std::is_same_v<get_deleter<T>, oup::default_delete>;
 
 template<typename T>
 constexpr bool has_base = std::is_base_of_v<test_object_derived, std::remove_cv_t<get_object<T>>>;


### PR DESCRIPTION
This PR does the following:
 - clean up the included headers in tests, in particular preventing `<algorithm>` from being included everywhere
 - update formatting to clang-format-15