### PR TITLE
Update snitch and CI dependencies

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
@@ -46,7 +46,7 @@ jobs:
 
     - name: Setup Emscripten
       if: matrix.platform.compiler == 'em++'
-      uses: mymindstorm/setup-emsdk@v7
+      uses: mymindstorm/setup-emsdk@v11
       with:
         version: ${{env.EM_VERSION}}
         actions-cache-folder: ${{env.EM_CACHE_FOLDER}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,7 +3,7 @@ name: CI
 on: push
 
 env:
-  EM_VERSION: 2.0.16
+  EM_VERSION: 2.0.34
   EM_CACHE_FOLDER: 'emsdk-cache'
   CODECOV_TOKEN: '99959e57-0b92-48b4-bf55-559d43d41b58'
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build_wasm/
 build_clang/
 doc/html/
 oup.sublime-workspace

--- a/oup.sublime-project
+++ b/oup.sublime-project
@@ -70,8 +70,8 @@
 					"shell_cmd": "make -j12 oup_speed_benchmark",
 				},
 				{
-					"name": "snatch",
-					"shell_cmd": "make -j12 snatch",
+					"name": "snitch",
+					"shell_cmd": "make -j12 snitch",
 				},
 			],
 			"working_dir": "$folder/build",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ include(FetchContent)
 
 FetchContent_Declare(snatch
                      GIT_REPOSITORY https://github.com/cschreib/snatch.git
-                     GIT_TAG        v0.1.3)
+                     GIT_TAG        c223246e1df6643745f00a89d6de22882fe70e58)
 FetchContent_MakeAvailable(snatch)
 
 set(RUNTIME_TEST_FILES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,10 +31,10 @@ endfunction()
 
 include(FetchContent)
 
-FetchContent_Declare(snatch
-                     GIT_REPOSITORY https://github.com/cschreib/snatch.git
-                     GIT_TAG        13c39e2cff643a8ce6672f02531a1f2f89ffafd2)
-FetchContent_MakeAvailable(snatch)
+FetchContent_Declare(snitch
+                     GIT_REPOSITORY https://github.com/cschreib/snitch.git
+                     GIT_TAG        08ac40f24b4ddaf6e9b205374af8d79313fa7eeb)
+FetchContent_MakeAvailable(snitch)
 
 set(RUNTIME_TEST_FILES
   ${PROJECT_SOURCE_DIR}/tests/tests_common.cpp
@@ -61,7 +61,7 @@ set(RUNTIME_TEST_FILES
 
 add_executable(oup_runtime_tests ${RUNTIME_TEST_FILES})
 target_link_libraries(oup_runtime_tests PRIVATE oup::oup)
-target_link_libraries(oup_runtime_tests PRIVATE snatch::snatch)
+target_link_libraries(oup_runtime_tests PRIVATE snitch::snitch)
 add_platform_definitions(oup_runtime_tests)
 
 add_custom_target(oup_runtime_tests_run

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ include(FetchContent)
 
 FetchContent_Declare(snatch
                      GIT_REPOSITORY https://github.com/cschreib/snatch.git
-                     GIT_TAG        c223246e1df6643745f00a89d6de22882fe70e58)
+                     GIT_TAG        c018968548ae30e20eac579c89a3e84e7aabbfc0)
 FetchContent_MakeAvailable(snatch)
 
 set(RUNTIME_TEST_FILES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ include(FetchContent)
 
 FetchContent_Declare(snatch
                      GIT_REPOSITORY https://github.com/cschreib/snatch.git
-                     GIT_TAG        c018968548ae30e20eac579c89a3e84e7aabbfc0)
+                     GIT_TAG        bb3b11fd01a26cc3557594425b95b99208a1e7c7)
 FetchContent_MakeAvailable(snatch)
 
 set(RUNTIME_TEST_FILES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ include(FetchContent)
 
 FetchContent_Declare(snatch
                      GIT_REPOSITORY https://github.com/cschreib/snatch.git
-                     GIT_TAG        bb3b11fd01a26cc3557594425b95b99208a1e7c7)
+                     GIT_TAG        13c39e2cff643a8ce6672f02531a1f2f89ffafd2)
 FetchContent_MakeAvailable(snatch)
 
 set(RUNTIME_TEST_FILES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ include(FetchContent)
 
 FetchContent_Declare(snitch
                      GIT_REPOSITORY https://github.com/cschreib/snitch.git
-                     GIT_TAG        3583e98245733979c902ff96f567ea765303582f)
+                     GIT_TAG        v1.0.0)
 FetchContent_MakeAvailable(snitch)
 
 set(RUNTIME_TEST_FILES

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ include(FetchContent)
 
 FetchContent_Declare(snitch
                      GIT_REPOSITORY https://github.com/cschreib/snitch.git
-                     GIT_TAG        08ac40f24b4ddaf6e9b205374af8d79313fa7eeb)
+                     GIT_TAG        3583e98245733979c902ff96f567ea765303582f)
 FetchContent_MakeAvailable(snitch)
 
 set(RUNTIME_TEST_FILES

--- a/tests/memory_tracker.hpp
+++ b/tests/memory_tracker.hpp
@@ -2,15 +2,15 @@
 #include <new>
 
 // Allocation tracker, to catch memory leaks and double delete
-constexpr std::size_t max_allocations = 20'000;
-extern void*          allocations[max_allocations];
-extern void*          allocations_array[max_allocations];
-extern std::size_t    allocations_bytes[max_allocations];
-extern std::size_t    num_allocations;
-extern std::size_t    size_allocations;
-extern std::size_t    double_delete;
-extern bool           memory_tracking;
-extern bool           force_next_allocation_failure;
+constexpr std::size_t       max_allocations = 20'000;
+extern volatile void*       allocations[max_allocations];
+extern volatile void*       allocations_array[max_allocations];
+extern volatile std::size_t allocations_bytes[max_allocations];
+extern volatile std::size_t num_allocations;
+extern volatile std::size_t size_allocations;
+extern volatile std::size_t double_delete;
+extern volatile bool        memory_tracking;
+extern volatile bool        force_next_allocation_failure;
 
 void* operator new(std::size_t size);
 
@@ -39,8 +39,8 @@ struct memory_tracker {
     memory_tracker() noexcept;
     ~memory_tracker() noexcept;
 
-    std::size_t allocated() const;
-    std::size_t double_delete() const;
+    std::size_t allocated() const volatile;
+    std::size_t double_delete() const volatile;
 };
 
 struct fail_next_allocation {

--- a/tests/runtime_tests_lifetime.cpp
+++ b/tests/runtime_tests_lifetime.cpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 TEMPLATE_LIST_TEST_CASE("observer expiring scope", "[lifetime][owner][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr;
@@ -25,11 +25,11 @@ TEMPLATE_LIST_TEST_CASE("observer expiring scope", "[lifetime][owner][observer]"
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer not expiring when owner moved", "[lifetime][owner][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType outer_ptr;
@@ -59,10 +59,10 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer expiring reset", "[lifetime][owner][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr;
@@ -82,12 +82,12 @@ TEMPLATE_LIST_TEST_CASE("observer expiring reset", "[lifetime][owner][observer]"
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "release valid owner with observer", "[lifetime][release][owner][observer]", owner_types) {
     if constexpr (!is_sealed<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             observer_ptr<TestType> optr;
@@ -126,14 +126,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "release valid owner with observer subobject",
     "[lifetime][release][owner][observer]",
     owner_types) {
     if constexpr (!is_sealed<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             state_observer_ptr<TestType> optr;
@@ -170,11 +170,11 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer get and raw get", "[lifetime][get][raw_get][owner][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr;
@@ -196,14 +196,14 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "object owning observer pointer to itself",
     "[lifetime][cycles][owner][observer]",
     owner_types) {
     if constexpr (is_cyclic<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr = make_pointer_deleter_1<TestType>();
@@ -214,12 +214,12 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "object owning observer pointer to other", "[lifetime][cycles][owner][observer]", owner_types) {
     if constexpr (is_cyclic<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr1 = make_pointer_deleter_1<TestType>();
@@ -232,14 +232,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "object owning observer pointer open chain",
     "[lifetime][cycles][owner][observer]",
     owner_types) {
     if constexpr (is_cyclic<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr1 = make_pointer_deleter_1<TestType>();
@@ -253,14 +253,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "object owning observer pointer open chain reversed",
     "[lifetime][cycles][owner][observer]",
     owner_types) {
     if constexpr (is_cyclic<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr1 = make_pointer_deleter_1<TestType>();
@@ -274,14 +274,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "object owning observer pointer closed chain interleaved",
     "[lifetime][cycles][owner][observer]",
     owner_types) {
     if constexpr (is_cyclic<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr1 = make_pointer_deleter_1<TestType>();
@@ -298,10 +298,10 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("pointers in vector", "[lifetime][array][owner][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         std::vector<TestType>               vec_own;
@@ -346,4 +346,4 @@ TEMPLATE_LIST_TEST_CASE("pointers in vector", "[lifetime][array][owner][observer
     }
 
     CHECK_NO_LEAKS;
-};
+}

--- a/tests/runtime_tests_lifetime.cpp
+++ b/tests/runtime_tests_lifetime.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 #include <algorithm>
 #include <vector>

--- a/tests/runtime_tests_make_observable.cpp
+++ b/tests/runtime_tests_make_observable.cpp
@@ -10,9 +10,9 @@ TEMPLATE_LIST_TEST_CASE("make observable", "[make_observable][owner]", owner_typ
             TestType ptr = oup::make_observable<get_object<TestType>, get_policy<TestType>>();
 
             if constexpr (is_sealed<TestType>) {
-                CHECK(mem_track.allocated() == 1u);
+                CHECK_MAX_ALLOC(1u);
             } else {
-                CHECK(mem_track.allocated() == 2u);
+                CHECK_MAX_ALLOC(2u);
             }
             CHECK(ptr.get() != nullptr);
             CHECK(ptr->state_ == test_object::state::default_init);
@@ -35,9 +35,9 @@ TEMPLATE_LIST_TEST_CASE("make observable with arguments", "[make_observable][own
                 test_object::state::special_init);
 
             if constexpr (is_sealed<TestType>) {
-                CHECK(mem_track.allocated() == 1u);
+                CHECK_MAX_ALLOC(1u);
             } else {
-                CHECK(mem_track.allocated() == 2u);
+                CHECK_MAX_ALLOC(2u);
             }
             CHECK(ptr.get() != nullptr);
             CHECK(ptr->state_ == test_object::state::special_init);
@@ -84,7 +84,7 @@ TEST_CASE("make observable unique", "[make_observable][owner]") {
     {
         TestType ptr = oup::make_observable_unique<test_object>();
 
-        CHECK(mem_track.allocated() == 2u);
+        CHECK_MAX_ALLOC(2u);
         CHECK(ptr.get() != nullptr);
         CHECK(ptr->state_ == test_object::state::default_init);
         CHECK_INSTANCES(1, 1);
@@ -100,7 +100,7 @@ TEST_CASE("make observable sealed", "[make_observable][owner]") {
     {
         TestType ptr = oup::make_observable_sealed<test_object>();
 
-        CHECK(mem_track.allocated() == 1u);
+        CHECK_MAX_ALLOC(1u);
         CHECK(ptr.get() != nullptr);
         CHECK(ptr->state_ == test_object::state::default_init);
         CHECK_INSTANCES(1, 1);

--- a/tests/runtime_tests_make_observable.cpp
+++ b/tests/runtime_tests_make_observable.cpp
@@ -4,7 +4,7 @@
 
 TEMPLATE_LIST_TEST_CASE("make observable", "[make_observable][owner]", owner_types) {
     if constexpr (can_use_make_observable<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr = oup::make_observable<get_object<TestType>, get_policy<TestType>>();
@@ -28,7 +28,7 @@ TEMPLATE_LIST_TEST_CASE("make observable", "[make_observable][owner]", owner_typ
 
 TEMPLATE_LIST_TEST_CASE("make observable with arguments", "[make_observable][owner]", owner_types) {
     if constexpr (can_use_make_observable<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr = oup::make_observable<get_object<TestType>, get_policy<TestType>>(
@@ -54,7 +54,7 @@ TEMPLATE_LIST_TEST_CASE("make observable with arguments", "[make_observable][own
 TEMPLATE_LIST_TEST_CASE(
     "make observable throw in constructor", "[make_observable][owner]", owner_types) {
     if constexpr (can_use_make_observable<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         next_test_object_constructor_throws = true;
         REQUIRE_THROWS_AS(
@@ -67,7 +67,7 @@ TEMPLATE_LIST_TEST_CASE(
 
 TEMPLATE_LIST_TEST_CASE("make observable bad alloc", "[make_observable][owner]", owner_types) {
     if constexpr (can_use_make_observable<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         force_next_allocation_failure = true;
         REQUIRE_THROWS_AS(
@@ -79,7 +79,7 @@ TEMPLATE_LIST_TEST_CASE("make observable bad alloc", "[make_observable][owner]",
 
 TEST_CASE("make observable unique", "[make_observable][owner]") {
     using TestType = oup::observable_unique_ptr<test_object>;
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = oup::make_observable_unique<test_object>();
@@ -95,7 +95,7 @@ TEST_CASE("make observable unique", "[make_observable][owner]") {
 
 TEST_CASE("make observable sealed", "[make_observable][owner]") {
     using TestType = oup::observable_sealed_ptr<test_object>;
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = oup::make_observable_sealed<test_object>();

--- a/tests/runtime_tests_make_observable.cpp
+++ b/tests/runtime_tests_make_observable.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("make observable", "[make_observable][owner]", owner_types) {
     if constexpr (can_use_make_observable<TestType>) {

--- a/tests/runtime_tests_make_observable.cpp
+++ b/tests/runtime_tests_make_observable.cpp
@@ -24,7 +24,7 @@ TEMPLATE_LIST_TEST_CASE("make observable", "[make_observable][owner]", owner_typ
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("make observable with arguments", "[make_observable][owner]", owner_types) {
     if constexpr (can_use_make_observable<TestType>) {
@@ -49,7 +49,7 @@ TEMPLATE_LIST_TEST_CASE("make observable with arguments", "[make_observable][own
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "make observable throw in constructor", "[make_observable][owner]", owner_types) {
@@ -63,7 +63,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("make observable bad alloc", "[make_observable][owner]", owner_types) {
     if constexpr (can_use_make_observable<TestType>) {
@@ -75,7 +75,7 @@ TEMPLATE_LIST_TEST_CASE("make observable bad alloc", "[make_observable][owner]",
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEST_CASE("make observable unique", "[make_observable][owner]") {
     using TestType = oup::observable_unique_ptr<test_object>;
@@ -91,7 +91,7 @@ TEST_CASE("make observable unique", "[make_observable][owner]") {
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEST_CASE("make observable sealed", "[make_observable][owner]") {
     using TestType = oup::observable_sealed_ptr<test_object>;
@@ -107,4 +107,4 @@ TEST_CASE("make observable sealed", "[make_observable][owner]") {
     }
 
     CHECK_NO_LEAKS;
-};
+}

--- a/tests/runtime_tests_observer_assignment_copy.cpp
+++ b/tests/runtime_tests_observer_assignment_copy.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy assignment operator valid to empty", "[assignment][observer]", owner_types) {
@@ -217,10 +216,10 @@ TEMPLATE_LIST_TEST_CASE(
     {
         TestType               ptr = make_pointer_deleter_1<TestType>();
         observer_ptr<TestType> optr{ptr};
-        SNATCH_WARNING_PUSH;
-        SNATCH_WARNING_DISABLE_SELF_ASSIGN;
+        SNITCH_WARNING_PUSH;
+        SNITCH_WARNING_DISABLE_SELF_ASSIGN;
         optr = optr;
-        SNATCH_WARNING_POP;
+        SNITCH_WARNING_POP;
 
         CHECK(optr.get() == ptr.get());
         CHECK(optr.expired() == false);
@@ -236,10 +235,10 @@ TEMPLATE_LIST_TEST_CASE(
 
     {
         observer_ptr<TestType> optr;
-        SNATCH_WARNING_PUSH;
-        SNATCH_WARNING_DISABLE_SELF_ASSIGN;
+        SNITCH_WARNING_PUSH;
+        SNITCH_WARNING_DISABLE_SELF_ASSIGN;
         optr = optr;
-        SNATCH_WARNING_POP;
+        SNITCH_WARNING_POP;
 
         CHECK(optr.get() == nullptr);
         CHECK(optr.expired() == true);

--- a/tests/runtime_tests_observer_assignment_copy.cpp
+++ b/tests/runtime_tests_observer_assignment_copy.cpp
@@ -4,7 +4,7 @@
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy assignment operator valid to empty", "[assignment][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr_orig = make_pointer_deleter_1<TestType>();
@@ -24,11 +24,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy assignment operator empty to valid", "[assignment][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr_orig;
@@ -48,11 +48,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy assignment operator empty to empty", "[assignment][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr_orig;
@@ -71,11 +71,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy assignment operator valid to valid", "[assignment][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr_orig = make_pointer_deleter_1<TestType>();
@@ -96,13 +96,13 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy assignment converting operator valid to empty",
     "[assignment][observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     if constexpr (has_base<TestType>) {
         {
@@ -124,13 +124,13 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy assignment converting operator empty to valid",
     "[assignment][observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     if constexpr (has_base<TestType>) {
         {
@@ -152,13 +152,13 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy assignment converting operator empty to empty",
     "[assignment][observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     if constexpr (has_base<TestType>) {
         {
@@ -179,13 +179,13 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy assignment converting operator valid to valid",
     "[assignment][observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     if constexpr (has_base<TestType>) {
         {
@@ -208,11 +208,11 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy assignment operator self to self valid", "[assignment][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr = make_pointer_deleter_1<TestType>();
@@ -228,11 +228,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy assignment operator self to self empty", "[assignment][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr;
@@ -247,4 +247,4 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}

--- a/tests/runtime_tests_observer_assignment_from_owner.cpp
+++ b/tests/runtime_tests_observer_assignment_from_owner.cpp
@@ -23,7 +23,7 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from owner assignment operator empty to valid",
@@ -48,7 +48,7 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from owner assignment operator empty to empty",
@@ -72,7 +72,7 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from owner assignment operator valid to valid",
@@ -100,7 +100,7 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from owner assignment converting operator valid to empty",
@@ -125,7 +125,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from owner assignment converting operator empty to valid",
@@ -152,7 +152,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from owner assignment converting operator empty to empty",
@@ -178,7 +178,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from owner assignment converting operator valid to valid",
@@ -208,4 +208,4 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}

--- a/tests/runtime_tests_observer_assignment_from_owner.cpp
+++ b/tests/runtime_tests_observer_assignment_from_owner.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from owner assignment operator valid to empty",

--- a/tests/runtime_tests_observer_assignment_move.cpp
+++ b/tests/runtime_tests_observer_assignment_move.cpp
@@ -4,7 +4,7 @@
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move assignment operator valid to empty", "[assignment][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr_orig = make_pointer_deleter_1<TestType>();
@@ -24,11 +24,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move assignment operator empty to valid", "[assignment][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr_orig;
@@ -48,11 +48,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move assignment operator empty to empty", "[assignment][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr_orig;
@@ -71,11 +71,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move assignment operator valid to valid", "[assignment][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr_orig = make_pointer_deleter_1<TestType>();
@@ -96,13 +96,13 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move assignment converting operator valid to empty",
     "[assignment][observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     if constexpr (has_base<TestType>) {
         {
@@ -124,13 +124,13 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move assignment converting operator empty to valid",
     "[assignment][observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     if constexpr (has_base<TestType>) {
         {
@@ -152,13 +152,13 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move assignment converting operator empty to empty",
     "[assignment][observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     if constexpr (has_base<TestType>) {
         {
@@ -179,13 +179,13 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move assignment converting operator valid to valid",
     "[assignment][observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     if constexpr (has_base<TestType>) {
         {
@@ -208,11 +208,11 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move assignment operator self to self valid", "[assignment][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr = make_pointer_deleter_1<TestType>();
@@ -224,11 +224,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move assignment operator self to self empty", "[assignment][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr;
@@ -239,4 +239,4 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}

--- a/tests/runtime_tests_observer_assignment_move.cpp
+++ b/tests/runtime_tests_observer_assignment_move.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move assignment operator valid to empty", "[assignment][observer]", owner_types) {

--- a/tests/runtime_tests_observer_cast_copy.cpp
+++ b/tests/runtime_tests_observer_cast_copy.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("observer static_cast copy from valid", "[cast][observer]", owner_types) {
     volatile memory_tracker mem_track;
@@ -16,7 +15,7 @@ TEMPLATE_LIST_TEST_CASE("observer static_cast copy from valid", "[cast][observer
 
             CHECK(optr1.get() == raw_ptr);
             CHECK(optr2.get() == raw_ptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             CHECK_INSTANCES(1, 1);
         };
 
@@ -43,7 +42,7 @@ TEMPLATE_LIST_TEST_CASE("observer static_cast copy from empty", "[cast][observer
 
             CHECK(optr1.get() == nullptr);
             CHECK(optr2.get() == nullptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             CHECK_INSTANCES(0, 1);
         };
 
@@ -71,7 +70,7 @@ TEMPLATE_LIST_TEST_CASE("observer const_cast copy from valid", "[cast][observer]
 
             CHECK(optr1.get() == raw_ptr);
             CHECK(optr2.get() == raw_ptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             CHECK_INSTANCES(1, 1);
         };
 
@@ -96,7 +95,7 @@ TEMPLATE_LIST_TEST_CASE("observer const_cast copy from empty", "[cast][observer]
 
             CHECK(optr1.get() == nullptr);
             CHECK(optr2.get() == nullptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             CHECK_INSTANCES(0, 1);
         };
 
@@ -123,7 +122,7 @@ TEMPLATE_LIST_TEST_CASE("observer dynamic_cast copy from valid", "[cast][observe
 
                 CHECK(optr1.get() == raw_ptr);
                 CHECK(optr2.get() == raw_ptr);
-                CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+                CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
                 CHECK_INSTANCES(1, 1);
             };
 
@@ -155,7 +154,7 @@ TEMPLATE_LIST_TEST_CASE("observer dynamic_cast copy from empty", "[cast][observe
 
                 CHECK(optr1.get() == nullptr);
                 CHECK(optr2.get() == nullptr);
-                CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+                CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
                 CHECK_INSTANCES(0, 1);
             };
 
@@ -190,7 +189,7 @@ TEMPLATE_LIST_TEST_CASE(
 
             CHECK(optr1.get() == raw_ptr);
             CHECK(optr2.get() == nullptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             CHECK_INSTANCES(1, 1);
         }
 

--- a/tests/runtime_tests_observer_cast_copy.cpp
+++ b/tests/runtime_tests_observer_cast_copy.cpp
@@ -3,7 +3,7 @@
 #include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("observer static_cast copy from valid", "[cast][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test = [&]<typename cast_type, typename expected_return_type>() {
@@ -28,10 +28,10 @@ TEMPLATE_LIST_TEST_CASE("observer static_cast copy from valid", "[cast][observer
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer static_cast copy from empty", "[cast][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test = [&]<typename cast_type, typename expected_return_type>() {
@@ -55,10 +55,10 @@ TEMPLATE_LIST_TEST_CASE("observer static_cast copy from empty", "[cast][observer
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer const_cast copy from valid", "[cast][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test = [&]<typename cast_type, typename expected_return_type>() {
@@ -81,10 +81,10 @@ TEMPLATE_LIST_TEST_CASE("observer const_cast copy from valid", "[cast][observer]
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer const_cast copy from empty", "[cast][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test = [&]<typename cast_type, typename expected_return_type>() {
@@ -106,10 +106,10 @@ TEMPLATE_LIST_TEST_CASE("observer const_cast copy from empty", "[cast][observer]
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer dynamic_cast copy from valid", "[cast][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test =
@@ -139,10 +139,10 @@ TEMPLATE_LIST_TEST_CASE("observer dynamic_cast copy from valid", "[cast][observe
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer dynamic_cast copy from empty", "[cast][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test =
@@ -171,12 +171,12 @@ TEMPLATE_LIST_TEST_CASE("observer dynamic_cast copy from empty", "[cast][observe
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer dynamic_cast copy from invalid", "[cast][observer]", owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType                    ptr0    = make_pointer_deleter_1<TestType>();
@@ -196,4 +196,4 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}

--- a/tests/runtime_tests_observer_cast_move.cpp
+++ b/tests/runtime_tests_observer_cast_move.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("observer static_cast move from valid", "[cast][observer]", owner_types) {
     volatile memory_tracker mem_track;
@@ -16,7 +15,7 @@ TEMPLATE_LIST_TEST_CASE("observer static_cast move from valid", "[cast][observer
 
             CHECK(optr1.get() == nullptr);
             CHECK(optr2.get() == raw_ptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             CHECK_INSTANCES(1, 1);
         };
 
@@ -43,7 +42,7 @@ TEMPLATE_LIST_TEST_CASE("observer static_cast move from empty", "[cast][observer
 
             CHECK(optr1.get() == nullptr);
             CHECK(optr2.get() == nullptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             CHECK_INSTANCES(0, 1);
         };
 
@@ -71,7 +70,7 @@ TEMPLATE_LIST_TEST_CASE("observer const_cast move from valid", "[cast][observer]
 
             CHECK(optr1.get() == nullptr);
             CHECK(optr2.get() == raw_ptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             CHECK_INSTANCES(1, 1);
         };
 
@@ -96,7 +95,7 @@ TEMPLATE_LIST_TEST_CASE("observer const_cast move from empty", "[cast][observer]
 
             CHECK(optr1.get() == nullptr);
             CHECK(optr2.get() == nullptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             CHECK_INSTANCES(0, 1);
         };
 
@@ -123,7 +122,7 @@ TEMPLATE_LIST_TEST_CASE("observer dynamic_cast move from valid", "[cast][observe
 
                 CHECK(optr1.get() == nullptr);
                 CHECK(optr2.get() == raw_ptr);
-                CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+                CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
                 CHECK_INSTANCES(1, 1);
             };
 
@@ -155,7 +154,7 @@ TEMPLATE_LIST_TEST_CASE("observer dynamic_cast move from empty", "[cast][observe
 
                 CHECK(optr1.get() == nullptr);
                 CHECK(optr2.get() == nullptr);
-                CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+                CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
                 CHECK_INSTANCES(0, 1);
             };
 
@@ -189,7 +188,7 @@ TEMPLATE_LIST_TEST_CASE(
 
             CHECK(optr1.get() == nullptr);
             CHECK(optr2.get() == nullptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             CHECK_INSTANCES(1, 1);
         }
 

--- a/tests/runtime_tests_observer_cast_move.cpp
+++ b/tests/runtime_tests_observer_cast_move.cpp
@@ -3,7 +3,7 @@
 #include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("observer static_cast move from valid", "[cast][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test = [&]<typename cast_type, typename expected_return_type>() {
@@ -28,10 +28,10 @@ TEMPLATE_LIST_TEST_CASE("observer static_cast move from valid", "[cast][observer
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer static_cast move from empty", "[cast][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test = [&]<typename cast_type, typename expected_return_type>() {
@@ -55,10 +55,10 @@ TEMPLATE_LIST_TEST_CASE("observer static_cast move from empty", "[cast][observer
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer const_cast move from valid", "[cast][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test = [&]<typename cast_type, typename expected_return_type>() {
@@ -81,10 +81,10 @@ TEMPLATE_LIST_TEST_CASE("observer const_cast move from valid", "[cast][observer]
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer const_cast move from empty", "[cast][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test = [&]<typename cast_type, typename expected_return_type>() {
@@ -106,10 +106,10 @@ TEMPLATE_LIST_TEST_CASE("observer const_cast move from empty", "[cast][observer]
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer dynamic_cast move from valid", "[cast][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test =
@@ -139,10 +139,10 @@ TEMPLATE_LIST_TEST_CASE("observer dynamic_cast move from valid", "[cast][observe
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer dynamic_cast move from empty", "[cast][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test =
@@ -171,12 +171,12 @@ TEMPLATE_LIST_TEST_CASE("observer dynamic_cast move from empty", "[cast][observe
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer dynamic_cast move from invalid", "[cast][observer]", owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType                    ptr0  = make_pointer_deleter_1<TestType>();
@@ -195,4 +195,4 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}

--- a/tests/runtime_tests_observer_comparison.cpp
+++ b/tests/runtime_tests_observer_comparison.cpp
@@ -4,7 +4,7 @@
 
 TEMPLATE_LIST_TEST_CASE(
     "observer comparison valid vs nullptr", "[comparison][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr = make_pointer_deleter_1<TestType>();
@@ -17,11 +17,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer comparison empty vs nullptr", "[comparison][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr;
@@ -33,11 +33,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer comparison empty vs empty", "[comparison][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr1;
@@ -50,11 +50,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer comparison empty vs valid", "[comparison][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr1;
@@ -68,13 +68,13 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer comparison valid vs valid different instance",
     "[comparison][observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr1 = make_pointer_deleter_1<TestType>();
@@ -89,11 +89,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer comparison valid vs valid same instance", "[comparison][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr = make_pointer_deleter_1<TestType>();
@@ -107,14 +107,14 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer comparison valid vs valid different instance derived",
     "[comparison][observer]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType                    ptr1 = make_pointer_deleter_1<TestType>();
@@ -130,14 +130,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer comparison valid vs valid same instance derived",
     "[comparison][observer]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType                    ptr = make_pointer_deleter_1<TestType>();
@@ -152,4 +152,4 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}

--- a/tests/runtime_tests_observer_comparison.cpp
+++ b/tests/runtime_tests_observer_comparison.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE(
     "observer comparison valid vs nullptr", "[comparison][observer]", owner_types) {

--- a/tests/runtime_tests_observer_construction.cpp
+++ b/tests/runtime_tests_observer_construction.cpp
@@ -3,7 +3,7 @@
 #include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("observer default constructor", "[construction][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> ptr;
@@ -14,10 +14,10 @@ TEMPLATE_LIST_TEST_CASE("observer default constructor", "[construction][observer
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer nullptr constructor", "[construction][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> ptr(nullptr);
@@ -28,4 +28,4 @@ TEMPLATE_LIST_TEST_CASE("observer nullptr constructor", "[construction][observer
     }
 
     CHECK_NO_LEAKS;
-};
+}

--- a/tests/runtime_tests_observer_construction.cpp
+++ b/tests/runtime_tests_observer_construction.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("observer default constructor", "[construction][observer]", owner_types) {
     volatile memory_tracker mem_track;

--- a/tests/runtime_tests_observer_construction_copy.cpp
+++ b/tests/runtime_tests_observer_construction_copy.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy constructor valid", "[construction][observer][from_observer]", owner_types) {

--- a/tests/runtime_tests_observer_construction_copy.cpp
+++ b/tests/runtime_tests_observer_construction_copy.cpp
@@ -4,7 +4,7 @@
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy constructor valid", "[construction][observer][from_observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr_owner = make_pointer_deleter_1<TestType>();
@@ -23,11 +23,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy constructor empty", "[construction][observer][from_observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> ptr_orig;
@@ -43,14 +43,14 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy from valid observer implicit conversion constructor",
     "[construction][observer][from_observer]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType               ptr_owner = make_pointer_deleter_1<TestType>();
@@ -70,14 +70,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy from empty observer implicit conversion constructor",
     "[construction][observer][from_observer]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             observer_ptr<TestType> ptr_orig;
@@ -96,14 +96,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy from valid observer explicit conversion constructor",
     "[construction][observer][from_observer]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             base_ptr<TestType>          ptr_owner = make_pointer_deleter_1<TestType>();
@@ -124,14 +124,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy from empty observer explicit conversion constructor",
     "[construction][observer][from_observer]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             base_observer_ptr<TestType> ptr_orig;
@@ -150,14 +150,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy from valid observer explicit conversion constructor with null",
     "[construction][observer][from_observer]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             base_ptr<TestType>          ptr_owner = make_pointer_deleter_1<TestType>();
@@ -177,13 +177,13 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer copy from valid observer explicit conversion constructor subobject",
     "[construction][observer][from_observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr_owner = make_pointer_deleter_1<TestType>();
@@ -202,4 +202,4 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}

--- a/tests/runtime_tests_observer_construction_from_owner.cpp
+++ b/tests/runtime_tests_observer_construction_from_owner.cpp
@@ -4,7 +4,7 @@
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from empty owner constructor", "[construction][observer][from_owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr_owner;
@@ -20,11 +20,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from valid owner constructor", "[construction][observer][from_owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr_owner = make_pointer_deleter_1<TestType>();
@@ -40,14 +40,14 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from empty owner conversion constructor",
     "[construction][observer][from_owner]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr_owner;
@@ -64,14 +64,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from valid owner conversion constructor",
     "[construction][observer][from_owner]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr_owner = make_pointer_deleter_1<TestType>();
@@ -88,14 +88,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from empty owner explicit conversion constructor",
     "[construction][observer][from_owner]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             base_ptr<TestType> ptr_owner;
@@ -112,14 +112,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from valid owner explicit conversion constructor",
     "[construction][observer][from_owner]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             base_ptr<TestType> ptr_owner = make_pointer_deleter_1<TestType>();
@@ -137,4 +137,4 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}

--- a/tests/runtime_tests_observer_construction_from_owner.cpp
+++ b/tests/runtime_tests_observer_construction_from_owner.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from empty owner constructor", "[construction][observer][from_owner]", owner_types) {

--- a/tests/runtime_tests_observer_construction_move.cpp
+++ b/tests/runtime_tests_observer_construction_move.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move from valid observer constructor",

--- a/tests/runtime_tests_observer_construction_move.cpp
+++ b/tests/runtime_tests_observer_construction_move.cpp
@@ -6,7 +6,7 @@ TEMPLATE_LIST_TEST_CASE(
     "observer move from valid observer constructor",
     "[construction][observer][from_observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr_owner = make_pointer_deleter_1<TestType>();
@@ -24,13 +24,13 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move from empty observer constructor",
     "[construction][observer][from_observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> ptr_orig;
@@ -47,14 +47,14 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move from valid observer implicit conversion constructor",
     "[construction][observer][from_observer]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType               ptr_owner = make_pointer_deleter_1<TestType>();
@@ -73,13 +73,13 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move from empty observer implicit conversion constructor",
     "[construction][observer][from_observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> ptr_orig;
@@ -97,7 +97,7 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move from valid observer explicit conversion constructor",
@@ -105,7 +105,7 @@ TEMPLATE_LIST_TEST_CASE(
     owner_types) {
 
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             base_ptr<TestType>          ptr_owner = make_pointer_deleter_1<TestType>();
@@ -126,14 +126,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move from empty observer explicit conversion constructor",
     "[construction][observer][from_observer]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             base_observer_ptr<TestType> ptr_orig;
@@ -153,14 +153,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move from valid observer explicit conversion constructor with null",
     "[construction][observer][from_observer]",
     owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             base_ptr<TestType>          ptr_owner = make_pointer_deleter_1<TestType>();
@@ -181,13 +181,13 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer move from valid observer explicit conversion constructor subobject",
     "[construction][observer][from_observer]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr_owner = make_pointer_deleter_1<TestType>();
@@ -206,4 +206,4 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}

--- a/tests/runtime_tests_observer_from_this.cpp
+++ b/tests/runtime_tests_observer_from_this.cpp
@@ -53,7 +53,7 @@ TEMPLATE_LIST_TEST_CASE("observer from this", "[observer_from_this]", owner_type
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from this with no owner heap", "[observer_from_this]", owner_types) {
@@ -90,7 +90,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer from this no owner stack", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType> && !eoft_constructor_takes_control_block<TestType>) {
@@ -123,7 +123,7 @@ TEMPLATE_LIST_TEST_CASE("observer from this no owner stack", "[observer_from_thi
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from this acquired into base owner as base", "[observer_from_this]", owner_types) {
@@ -159,7 +159,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from this acquired into base owner as derived", "[observer_from_this]", owner_types) {
@@ -179,7 +179,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from this after owner reset to empty", "[observer_from_this]", owner_types) {
@@ -203,7 +203,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from this after owner reset to valid", "[observer_from_this]", owner_types) {
@@ -227,7 +227,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from this after owner release", "[observer_from_this]", owner_types) {
@@ -257,7 +257,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from this after owner release then reset to same",
@@ -295,7 +295,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from this after owner move", "[observer_from_this]", owner_types) {
@@ -318,7 +318,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer from this after owner move assignment", "[observer_from_this]", owner_types) {
@@ -342,7 +342,7 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEST_CASE("observer from this multiple inheritance", "[observer_from_this]") {
     using base       = test_object_observer_from_this_unique;
@@ -371,7 +371,7 @@ TEST_CASE("observer from this multiple inheritance", "[observer_from_this]") {
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer from this in constructor", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType> && has_eoft_self_member<TestType>) {
@@ -395,4 +395,4 @@ TEMPLATE_LIST_TEST_CASE("observer from this in constructor", "[observer_from_thi
 
         CHECK_NO_LEAKS;
     }
-};
+}

--- a/tests/runtime_tests_observer_from_this.cpp
+++ b/tests/runtime_tests_observer_from_this.cpp
@@ -4,7 +4,7 @@
 
 TEMPLATE_LIST_TEST_CASE("observer from this", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType                    ptr      = make_pointer_deleter_1<TestType>();
@@ -58,7 +58,7 @@ TEMPLATE_LIST_TEST_CASE("observer from this", "[observer_from_this]", owner_type
 TEMPLATE_LIST_TEST_CASE(
     "observer from this with no owner heap", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType> && !must_use_make_observable<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             get_object<TestType>* orig_ptr = make_instance<TestType>();
@@ -94,7 +94,7 @@ TEMPLATE_LIST_TEST_CASE(
 
 TEMPLATE_LIST_TEST_CASE("observer from this no owner stack", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType> && !eoft_constructor_takes_control_block<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             get_object<TestType> obj;
@@ -128,7 +128,7 @@ TEMPLATE_LIST_TEST_CASE("observer from this no owner stack", "[observer_from_thi
 TEMPLATE_LIST_TEST_CASE(
     "observer from this acquired into base owner as base", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType> && !must_use_make_observable<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             get_object<TestType>*      orig_ptr      = make_instance<TestType>();
@@ -164,7 +164,7 @@ TEMPLATE_LIST_TEST_CASE(
 TEMPLATE_LIST_TEST_CASE(
     "observer from this acquired into base owner as derived", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType> && has_base<TestType> && !must_use_make_observable<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             get_object<TestType>* orig_ptr = make_instance<TestType>();
@@ -184,7 +184,7 @@ TEMPLATE_LIST_TEST_CASE(
 TEMPLATE_LIST_TEST_CASE(
     "observer from this after owner reset to empty", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr  = make_pointer_deleter_1<TestType>();
@@ -208,7 +208,7 @@ TEMPLATE_LIST_TEST_CASE(
 TEMPLATE_LIST_TEST_CASE(
     "observer from this after owner reset to valid", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType> && can_reset_to_new<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr  = make_pointer_deleter_1<TestType>();
@@ -232,7 +232,7 @@ TEMPLATE_LIST_TEST_CASE(
 TEMPLATE_LIST_TEST_CASE(
     "observer from this after owner release", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType> && can_release<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr  = make_pointer_deleter_1<TestType>();
@@ -264,7 +264,7 @@ TEMPLATE_LIST_TEST_CASE(
     "[observer_from_this]",
     owner_types) {
     if constexpr (has_eoft<TestType> && can_release<TestType> && can_reset_to_new<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr  = make_pointer_deleter_1<TestType>();
@@ -300,7 +300,7 @@ TEMPLATE_LIST_TEST_CASE(
 TEMPLATE_LIST_TEST_CASE(
     "observer from this after owner move", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr1 = make_pointer_deleter_1<TestType>();
@@ -323,7 +323,7 @@ TEMPLATE_LIST_TEST_CASE(
 TEMPLATE_LIST_TEST_CASE(
     "observer from this after owner move assignment", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr1 = make_pointer_deleter_1<TestType>();
@@ -353,7 +353,7 @@ TEST_CASE("observer from this multiple inheritance", "[observer_from_this]") {
     using eoft_deriv = oup::enable_observer_from_this_unique<deriv>;
     using TestType   = ptr_deriv;
 
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         deriv*    raw_ptr_deriv = new deriv;
@@ -375,7 +375,7 @@ TEST_CASE("observer from this multiple inheritance", "[observer_from_this]") {
 
 TEMPLATE_LIST_TEST_CASE("observer from this in constructor", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType> && has_eoft_self_member<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         if constexpr (eoft_always_has_block<TestType>) {
             next_test_object_constructor_calls_observer_from_this = true;

--- a/tests/runtime_tests_observer_from_this.cpp
+++ b/tests/runtime_tests_observer_from_this.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("observer from this", "[observer_from_this]", owner_types) {
     if constexpr (has_eoft<TestType>) {
@@ -74,12 +73,12 @@ TEMPLATE_LIST_TEST_CASE(
             } else {
                 REQUIRE_THROWS_MATCHES(
                     (make_observer_from_this<TestType>(orig_ptr)), oup::bad_observer_from_this,
-                    snatch::matchers::with_what_contains{
+                    snitch::matchers::with_what_contains{
                         "observer_from_this() called with uninitialized control block"});
                 REQUIRE_THROWS_MATCHES(
                     (make_const_observer_from_this<TestType>(orig_ptr)),
                     oup::bad_observer_from_this,
-                    snatch::matchers::with_what_contains{
+                    snitch::matchers::with_what_contains{
                         "observer_from_this() called with uninitialized control block"});
             }
 
@@ -110,11 +109,11 @@ TEMPLATE_LIST_TEST_CASE("observer from this no owner stack", "[observer_from_thi
             } else {
                 REQUIRE_THROWS_MATCHES(
                     (make_observer_from_this<TestType>(&obj)), oup::bad_observer_from_this,
-                    snatch::matchers::with_what_contains{
+                    snitch::matchers::with_what_contains{
                         "observer_from_this() called with uninitialized control block"});
                 REQUIRE_THROWS_MATCHES(
                     (make_const_observer_from_this<TestType>(&obj)), oup::bad_observer_from_this,
-                    snatch::matchers::with_what_contains{
+                    snitch::matchers::with_what_contains{
                         "observer_from_this() called with uninitialized control block"});
             }
 
@@ -147,12 +146,12 @@ TEMPLATE_LIST_TEST_CASE(
             } else {
                 REQUIRE_THROWS_MATCHES(
                     (make_observer_from_this<TestType>(orig_ptr)), oup::bad_observer_from_this,
-                    snatch::matchers::with_what_contains{
+                    snitch::matchers::with_what_contains{
                         "observer_from_this() called with uninitialized control block"});
                 REQUIRE_THROWS_MATCHES(
                     (make_const_observer_from_this<TestType>(orig_ptr)),
                     oup::bad_observer_from_this,
-                    snatch::matchers::with_what_contains{
+                    snitch::matchers::with_what_contains{
                         "observer_from_this() called with uninitialized control block"});
             }
         }
@@ -388,7 +387,7 @@ TEMPLATE_LIST_TEST_CASE("observer from this in constructor", "[observer_from_thi
             next_test_object_constructor_calls_observer_from_this = true;
             REQUIRE_THROWS_MATCHES(
                 (make_pointer_deleter_1<TestType>()), oup::bad_observer_from_this,
-                snatch::matchers::with_what_contains{
+                snitch::matchers::with_what_contains{
                     "observer_from_this() called with uninitialized control block"});
             next_test_object_constructor_calls_observer_from_this = false;
         }

--- a/tests/runtime_tests_observer_misc.cpp
+++ b/tests/runtime_tests_observer_misc.cpp
@@ -4,10 +4,10 @@
 
 TEMPLATE_LIST_TEST_CASE("observer size", "[size][observer]", owner_types) {
     CHECK(sizeof(observer_ptr<TestType>) == 2 * sizeof(void*));
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer reset to null", "[reset][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr = make_pointer_deleter_1<TestType>();
@@ -19,10 +19,10 @@ TEMPLATE_LIST_TEST_CASE("observer reset to null", "[reset][observer]", owner_typ
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer swap empty vs empty", "[swap][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr1;
@@ -36,10 +36,10 @@ TEMPLATE_LIST_TEST_CASE("observer swap empty vs empty", "[swap][observer]", owne
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer swap valid vs empty", "[swap][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr1 = make_pointer_deleter_1<TestType>();
@@ -55,10 +55,10 @@ TEMPLATE_LIST_TEST_CASE("observer swap valid vs empty", "[swap][observer]", owne
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer swap empty vs valid", "[swap][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr2 = make_pointer_deleter_2<TestType>();
@@ -74,10 +74,10 @@ TEMPLATE_LIST_TEST_CASE("observer swap empty vs valid", "[swap][observer]", owne
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer swap valid vs valid", "[swap][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr1 = make_pointer_deleter_1<TestType>();
@@ -95,11 +95,11 @@ TEMPLATE_LIST_TEST_CASE("observer swap valid vs valid", "[swap][observer]", owne
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "observer swap valid vs valid same instance", "[swap][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr = make_pointer_deleter_1<TestType>();
@@ -114,10 +114,10 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer swap self vs self empty", "[swap][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr;
@@ -128,10 +128,10 @@ TEMPLATE_LIST_TEST_CASE("observer swap self vs self empty", "[swap][observer]", 
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer swap self vs self valid", "[swap][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr = make_pointer_deleter_1<TestType>();
@@ -143,10 +143,10 @@ TEMPLATE_LIST_TEST_CASE("observer swap self vs self valid", "[swap][observer]", 
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer dereference valid", "[dereference][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr = make_pointer_deleter_1<TestType>();
@@ -156,10 +156,10 @@ TEMPLATE_LIST_TEST_CASE("observer dereference valid", "[dereference][observer]",
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer get valid", "[get][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr = make_pointer_deleter_1<TestType>();
@@ -169,10 +169,10 @@ TEMPLATE_LIST_TEST_CASE("observer get valid", "[get][observer]", owner_types) {
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer get empty", "[get][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr;
@@ -180,10 +180,10 @@ TEMPLATE_LIST_TEST_CASE("observer get empty", "[get][observer]", owner_types) {
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer raw_get valid", "[raw_get][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr = make_pointer_deleter_1<TestType>();
@@ -193,10 +193,10 @@ TEMPLATE_LIST_TEST_CASE("observer raw_get valid", "[raw_get][observer]", owner_t
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer raw_get empty", "[raw_get][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr;
@@ -204,10 +204,10 @@ TEMPLATE_LIST_TEST_CASE("observer raw_get empty", "[raw_get][observer]", owner_t
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer operator bool valid", "[bool][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType               ptr = make_pointer_deleter_1<TestType>();
@@ -219,10 +219,10 @@ TEMPLATE_LIST_TEST_CASE("observer operator bool valid", "[bool][observer]", owne
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("observer operator bool empty", "[bool][observer]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         observer_ptr<TestType> optr;
@@ -232,4 +232,4 @@ TEMPLATE_LIST_TEST_CASE("observer operator bool empty", "[bool][observer]", owne
     }
 
     CHECK_NO_LEAKS;
-};
+}

--- a/tests/runtime_tests_observer_misc.cpp
+++ b/tests/runtime_tests_observer_misc.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("observer size", "[size][observer]", owner_types) {
     CHECK(sizeof(observer_ptr<TestType>) == 2 * sizeof(void*));

--- a/tests/runtime_tests_owner_assignment_move.cpp
+++ b/tests/runtime_tests_owner_assignment_move.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE(
     "owner move assignment operator valid to empty", "[assignment][owner]", owner_types) {

--- a/tests/runtime_tests_owner_assignment_move.cpp
+++ b/tests/runtime_tests_owner_assignment_move.cpp
@@ -4,7 +4,7 @@
 
 TEMPLATE_LIST_TEST_CASE(
     "owner move assignment operator valid to empty", "[assignment][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr_orig = make_pointer_deleter_1<TestType>();
@@ -23,11 +23,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner move assignment operator empty to valid", "[assignment][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr_orig = make_empty_pointer_deleter_1<TestType>();
@@ -46,11 +46,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner move assignment operator empty to empty", "[assignment][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr_orig = make_empty_pointer_deleter_1<TestType>();
@@ -69,11 +69,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner move assignment operator valid to valid", "[assignment][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr_orig     = make_pointer_deleter_1<TestType>();
@@ -93,13 +93,13 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner move assignment converting operator valid to empty",
     "[assignment][owner]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr_orig = make_pointer_deleter_1<TestType>();
@@ -118,13 +118,13 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner move assignment converting operator empty to valid",
     "[assignment][owner]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr_orig = make_empty_pointer_deleter_1<TestType>();
@@ -143,13 +143,13 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner move assignment converting operator empty to empty",
     "[assignment][owner]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr_orig = make_empty_pointer_deleter_1<TestType>();
@@ -168,13 +168,13 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner move assignment converting operator valid to valid",
     "[assignment][owner]",
     owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr_orig     = make_pointer_deleter_1<TestType>();
@@ -194,11 +194,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner move assignment operator self to self valid", "[assignment][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = make_pointer_deleter_1<TestType>();
@@ -212,11 +212,11 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner move assignment operator self to self empty", "[assignment][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = make_empty_pointer_deleter_1<TestType>();
@@ -230,4 +230,4 @@ TEMPLATE_LIST_TEST_CASE(
     }
 
     CHECK_NO_LEAKS;
-};
+}

--- a/tests/runtime_tests_owner_cast_move.cpp
+++ b/tests/runtime_tests_owner_cast_move.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 // For std::bad_cast
 #include <typeinfo>
@@ -18,7 +17,7 @@ TEMPLATE_LIST_TEST_CASE("owner static_cast move from valid", "[cast][owner]", ow
 
             CHECK(ptr1.get() == nullptr);
             CHECK(ptr2.get() == raw_ptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             if constexpr (has_stateful_deleter<TestType>) {
                 CHECK(ptr2.get_deleter().state_ == test_deleter::state::special_init_1);
             }
@@ -47,7 +46,7 @@ TEMPLATE_LIST_TEST_CASE("owner static_cast move from empty", "[cast][owner]", ow
 
             CHECK(ptr1.get() == nullptr);
             CHECK(ptr2.get() == nullptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             if constexpr (has_stateful_deleter<TestType>) {
                 CHECK(ptr2.get_deleter().state_ == test_deleter::state::special_init_1);
             }
@@ -77,7 +76,7 @@ TEMPLATE_LIST_TEST_CASE("owner const_cast move from valid", "[cast][owner]", own
 
             CHECK(ptr1.get() == nullptr);
             CHECK(ptr2.get() == raw_ptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             if constexpr (has_stateful_deleter<TestType>) {
                 CHECK(ptr2.get_deleter().state_ == test_deleter::state::special_init_1);
             }
@@ -104,7 +103,7 @@ TEMPLATE_LIST_TEST_CASE("owner const_cast move from empty", "[cast][owner]", own
 
             CHECK(ptr1.get() == nullptr);
             CHECK(ptr2.get() == nullptr);
-            CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+            CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
             if constexpr (has_stateful_deleter<TestType>) {
                 CHECK(ptr2.get_deleter().state_ == test_deleter::state::special_init_1);
             }
@@ -134,7 +133,7 @@ TEMPLATE_LIST_TEST_CASE("owner dynamic_cast move from valid", "[cast][owner]", o
 
                 CHECK(ptr1.get() == nullptr);
                 CHECK(ptr2.get() == raw_ptr);
-                CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+                CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
                 if constexpr (has_stateful_deleter<TestType>) {
                     CHECK(ptr2.get_deleter().state_ == test_deleter::state::special_init_1);
                 }
@@ -166,7 +165,7 @@ TEMPLATE_LIST_TEST_CASE("owner dynamic_cast move from empty", "[cast][owner]", o
 
                 CHECK(ptr1.get() == nullptr);
                 CHECK(ptr2.get() == nullptr);
-                CHECK(snatch::type_name<return_type> == snatch::type_name<expected_return_type>);
+                CHECK(snitch::type_name<return_type> == snitch::type_name<expected_return_type>);
                 if constexpr (has_stateful_deleter<TestType>) {
                     CHECK(ptr2.get_deleter().state_ == test_deleter::state::special_init_1);
                 }

--- a/tests/runtime_tests_owner_cast_move.cpp
+++ b/tests/runtime_tests_owner_cast_move.cpp
@@ -6,7 +6,7 @@
 #include <typeinfo>
 
 TEMPLATE_LIST_TEST_CASE("owner static_cast move from valid", "[cast][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test = [&]<typename cast_type, typename expected_return_type>() {
@@ -33,10 +33,10 @@ TEMPLATE_LIST_TEST_CASE("owner static_cast move from valid", "[cast][owner]", ow
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner static_cast move from empty", "[cast][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test = [&]<typename cast_type, typename expected_return_type>() {
@@ -62,10 +62,10 @@ TEMPLATE_LIST_TEST_CASE("owner static_cast move from empty", "[cast][owner]", ow
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner const_cast move from valid", "[cast][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test = [&]<typename cast_type, typename expected_return_type>() {
@@ -90,10 +90,10 @@ TEMPLATE_LIST_TEST_CASE("owner const_cast move from valid", "[cast][owner]", own
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner const_cast move from empty", "[cast][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test = [&]<typename cast_type, typename expected_return_type>() {
@@ -117,10 +117,10 @@ TEMPLATE_LIST_TEST_CASE("owner const_cast move from empty", "[cast][owner]", own
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner dynamic_cast move from valid", "[cast][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test =
@@ -150,10 +150,10 @@ TEMPLATE_LIST_TEST_CASE("owner dynamic_cast move from valid", "[cast][owner]", o
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner dynamic_cast move from empty", "[cast][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         auto run_test =
@@ -182,11 +182,11 @@ TEMPLATE_LIST_TEST_CASE("owner dynamic_cast move from empty", "[cast][owner]", o
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner dynamic_cast move from invalid", "[cast][owner]", owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType              ptr0    = make_pointer_deleter_1<TestType>();
@@ -205,4 +205,4 @@ TEMPLATE_LIST_TEST_CASE("owner dynamic_cast move from invalid", "[cast][owner]",
 
         CHECK_NO_LEAKS;
     }
-};
+}

--- a/tests/runtime_tests_owner_comparison.cpp
+++ b/tests/runtime_tests_owner_comparison.cpp
@@ -3,7 +3,7 @@
 #include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("owner comparison valid vs nullptr", "[comparison][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = make_pointer_deleter_1<TestType>();
@@ -15,10 +15,10 @@ TEMPLATE_LIST_TEST_CASE("owner comparison valid vs nullptr", "[comparison][owner
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner comparison empty vs nullptr", "[comparison][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = make_empty_pointer_deleter_1<TestType>();
@@ -30,10 +30,10 @@ TEMPLATE_LIST_TEST_CASE("owner comparison empty vs nullptr", "[comparison][owner
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner comparison empty vs empty", "[comparison][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr1 = make_empty_pointer_deleter_1<TestType>();
@@ -46,10 +46,10 @@ TEMPLATE_LIST_TEST_CASE("owner comparison empty vs empty", "[comparison][owner]"
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner comparison empty vs valid", "[comparison][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr1 = make_empty_pointer_deleter_1<TestType>();
@@ -62,10 +62,10 @@ TEMPLATE_LIST_TEST_CASE("owner comparison empty vs valid", "[comparison][owner]"
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner comparison valid vs valid", "[comparison][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr1 = make_pointer_deleter_1<TestType>();
@@ -78,4 +78,4 @@ TEMPLATE_LIST_TEST_CASE("owner comparison valid vs valid", "[comparison][owner]"
     }
 
     CHECK_NO_LEAKS;
-};
+}

--- a/tests/runtime_tests_owner_comparison.cpp
+++ b/tests/runtime_tests_owner_comparison.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("owner comparison valid vs nullptr", "[comparison][owner]", owner_types) {
     volatile memory_tracker mem_track;

--- a/tests/runtime_tests_owner_construction.cpp
+++ b/tests/runtime_tests_owner_construction.cpp
@@ -3,7 +3,7 @@
 #include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("owner default constructor", "[construction][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr;
@@ -16,10 +16,10 @@ TEMPLATE_LIST_TEST_CASE("owner default constructor", "[construction][owner]", ow
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner nullptr constructor", "[construction][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr(nullptr);
@@ -32,10 +32,10 @@ TEMPLATE_LIST_TEST_CASE("owner nullptr constructor", "[construction][owner]", ow
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner move constructor", "[construction][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr_orig = make_pointer_deleter_1<TestType>();
@@ -53,11 +53,11 @@ TEMPLATE_LIST_TEST_CASE("owner move constructor", "[construction][owner]", owner
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner acquiring constructor", "[construction][owner]", owner_types) {
     if constexpr (!must_use_make_observable<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr(make_instance<TestType>());
@@ -71,12 +71,12 @@ TEMPLATE_LIST_TEST_CASE("owner acquiring constructor", "[construction][owner]", 
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner acquiring constructor with deleter", "[construction][owner]", owner_types) {
     if constexpr (!must_use_make_observable<TestType> && has_stateful_deleter<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr(make_instance<TestType>(), make_deleter_instance_1<TestType>());
@@ -90,12 +90,12 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner acquiring constructor bad alloc", "[construction][owner]", owner_types) {
     if constexpr (!must_use_make_observable<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             auto* raw_ptr = make_instance<TestType>();
@@ -108,12 +108,12 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner acquiring constructor bad alloc with deleter", "[construction][owner]", owner_types) {
     if constexpr (!must_use_make_observable<TestType> && has_stateful_deleter<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             auto* raw_ptr = make_instance<TestType>();
@@ -128,11 +128,11 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner acquiring constructor null", "[construction][owner]", owner_types) {
     if constexpr (!must_use_make_observable<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr(static_cast<get_object<TestType>*>(nullptr));
@@ -146,12 +146,12 @@ TEMPLATE_LIST_TEST_CASE("owner acquiring constructor null", "[construction][owne
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner implicit conversion constructor", "[construction][owner]", owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr_orig = make_pointer_deleter_1<TestType>();
@@ -171,12 +171,12 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner explicit conversion constructor", "[construction][owner]", owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             base_ptr<TestType> ptr_orig = make_pointer_deleter_1<TestType>();
@@ -197,14 +197,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner explicit conversion constructor with custom deleter",
     "[construction][owner]",
     owner_types) {
     if constexpr (has_base<TestType> && has_stateful_deleter<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             base_ptr<TestType> ptr_orig = make_pointer_deleter_1<TestType>();
@@ -226,12 +226,12 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner explicit conversion constructor with null", "[construction][owner]", owner_types) {
     if constexpr (has_base<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             base_ptr<TestType> ptr_orig = make_pointer_deleter_1<TestType>();
@@ -251,14 +251,14 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE(
     "owner explicit conversion constructor with custom deleter with null",
     "[construction][owner]",
     owner_types) {
     if constexpr (has_base<TestType> && has_stateful_deleter<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             base_ptr<TestType> ptr_orig = make_pointer_deleter_1<TestType>();
@@ -280,4 +280,4 @@ TEMPLATE_LIST_TEST_CASE(
 
         CHECK_NO_LEAKS;
     }
-};
+}

--- a/tests/runtime_tests_owner_construction.cpp
+++ b/tests/runtime_tests_owner_construction.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("owner default constructor", "[construction][owner]", owner_types) {
     volatile memory_tracker mem_track;

--- a/tests/runtime_tests_owner_misc.cpp
+++ b/tests/runtime_tests_owner_misc.cpp
@@ -17,10 +17,10 @@ TEMPLATE_LIST_TEST_CASE("owner size", "[size][owner]", owner_types) {
             : round_up(sizeof(deleter_type), std::max(alignof(deleter_type), alignof(void*)));
 
     CHECK(sizeof(TestType) == 2 * sizeof(void*) + deleter_overhead);
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner reset to null", "[reset][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = make_pointer_deleter_1<TestType>();
@@ -34,11 +34,11 @@ TEMPLATE_LIST_TEST_CASE("owner reset to null", "[reset][owner]", owner_types) {
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner reset to new", "[reset][owner]", owner_types) {
     if constexpr (!must_use_make_observable<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr          = make_pointer_deleter_1<TestType>();
@@ -55,11 +55,11 @@ TEMPLATE_LIST_TEST_CASE("owner reset to new", "[reset][owner]", owner_types) {
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner reset to new bad alloc", "[reset][owner]", owner_types) {
     if constexpr (!must_use_make_observable<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             auto*    raw_ptr1 = make_instance<TestType>();
@@ -92,10 +92,10 @@ TEMPLATE_LIST_TEST_CASE("owner reset to new bad alloc", "[reset][owner]", owner_
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner swap empty vs empty", "[swap][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr1 = make_empty_pointer_deleter_1<TestType>();
@@ -112,10 +112,10 @@ TEMPLATE_LIST_TEST_CASE("owner swap empty vs empty", "[swap][owner]", owner_type
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner swap valid vs empty", "[swap][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr1 = make_pointer_deleter_1<TestType>();
@@ -132,10 +132,10 @@ TEMPLATE_LIST_TEST_CASE("owner swap valid vs empty", "[swap][owner]", owner_type
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner swap empty vs valid", "[swap][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr1 = make_empty_pointer_deleter_1<TestType>();
@@ -152,10 +152,10 @@ TEMPLATE_LIST_TEST_CASE("owner swap empty vs valid", "[swap][owner]", owner_type
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner swap valid vs valid", "[swap][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr1     = make_pointer_deleter_1<TestType>();
@@ -176,10 +176,10 @@ TEMPLATE_LIST_TEST_CASE("owner swap valid vs valid", "[swap][owner]", owner_type
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner swap self vs self empty", "[swap][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = make_empty_pointer_deleter_1<TestType>();
@@ -193,10 +193,10 @@ TEMPLATE_LIST_TEST_CASE("owner swap self vs self empty", "[swap][owner]", owner_
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner swap self vs self valid", "[swap][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = make_pointer_deleter_1<TestType>();
@@ -210,10 +210,10 @@ TEMPLATE_LIST_TEST_CASE("owner swap self vs self valid", "[swap][owner]", owner_
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner dereference valid", "[dereference][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = make_pointer_deleter_1<TestType>();
@@ -223,10 +223,10 @@ TEMPLATE_LIST_TEST_CASE("owner dereference valid", "[dereference][owner]", owner
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner get valid", "[get][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = make_pointer_deleter_1<TestType>();
@@ -236,10 +236,10 @@ TEMPLATE_LIST_TEST_CASE("owner get valid", "[get][owner]", owner_types) {
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner get empty", "[get][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = make_empty_pointer_deleter_1<TestType>();
@@ -248,10 +248,10 @@ TEMPLATE_LIST_TEST_CASE("owner get empty", "[get][owner]", owner_types) {
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner operator bool valid", "[bool][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = make_pointer_deleter_1<TestType>();
@@ -263,10 +263,10 @@ TEMPLATE_LIST_TEST_CASE("owner operator bool valid", "[bool][owner]", owner_type
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner operator bool empty", "[bool][owner]", owner_types) {
-    memory_tracker mem_track;
+    volatile memory_tracker mem_track;
 
     {
         TestType ptr = make_empty_pointer_deleter_1<TestType>();
@@ -277,11 +277,11 @@ TEMPLATE_LIST_TEST_CASE("owner operator bool empty", "[bool][owner]", owner_type
     }
 
     CHECK_NO_LEAKS;
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner release valid", "[release][owner]", owner_types) {
     if constexpr (!is_sealed<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr          = make_pointer_deleter_1<TestType>();
@@ -300,11 +300,11 @@ TEMPLATE_LIST_TEST_CASE("owner release valid", "[release][owner]", owner_types) 
 
         CHECK_NO_LEAKS;
     }
-};
+}
 
 TEMPLATE_LIST_TEST_CASE("owner release empty", "[release][owner]", owner_types) {
     if constexpr (!is_sealed<TestType>) {
-        memory_tracker mem_track;
+        volatile memory_tracker mem_track;
 
         {
             TestType ptr          = make_empty_pointer_deleter_1<TestType>();
@@ -320,4 +320,4 @@ TEMPLATE_LIST_TEST_CASE("owner release empty", "[release][owner]", owner_types) 
 
         CHECK_NO_LEAKS;
     }
-};
+}

--- a/tests/runtime_tests_owner_misc.cpp
+++ b/tests/runtime_tests_owner_misc.cpp
@@ -1,6 +1,5 @@
 #include "memory_tracker.hpp"
 #include "testing.hpp"
-#include "tests_common.hpp"
 
 TEMPLATE_LIST_TEST_CASE("owner size", "[size][owner]", owner_types) {
     using deleter_type = get_deleter<TestType>;

--- a/tests/testing.hpp
+++ b/tests/testing.hpp
@@ -1,1 +1,78 @@
-#include "snatch/snatch.hpp"
+#include "snitch/snitch.hpp"
+#include "tests_common.hpp"
+
+// clang-format off
+using owner_types = snitch::type_list<
+    oup::observable_unique_ptr<test_object>,
+    oup::observable_sealed_ptr<test_object>,
+    oup::observable_unique_ptr<const test_object>,
+    oup::observable_sealed_ptr<const test_object>,
+    oup::observable_unique_ptr<test_object_derived>,
+    oup::observable_sealed_ptr<test_object_derived>,
+    oup::observable_unique_ptr<test_object, test_deleter>,
+    oup::observable_unique_ptr<test_object_derived, test_deleter>,
+    oup::observable_unique_ptr<test_object_observer_from_this_unique>,
+    oup::observable_sealed_ptr<test_object_observer_from_this_sealed>,
+    oup::basic_observable_ptr<test_object_observer_from_this_non_virtual_unique, oup::default_delete, unique_non_virtual_policy>,
+    oup::basic_observable_ptr<test_object_observer_from_this_maybe_no_block_unique, oup::default_delete, unique_maybe_no_block_policy>,
+    oup::basic_observable_ptr<test_object_observer_from_this_virtual_sealed, oup::placement_delete, sealed_virtual_policy>,
+    oup::observable_unique_ptr<const test_object_observer_from_this_unique>,
+    oup::observable_sealed_ptr<const test_object_observer_from_this_sealed>,
+    oup::observable_unique_ptr<test_object_observer_from_this_derived_unique>,
+    oup::observable_sealed_ptr<test_object_observer_from_this_derived_sealed>,
+    oup::observable_unique_ptr<test_object_observer_from_this_multi_unique>,
+    oup::observable_sealed_ptr<test_object_observer_from_this_multi_sealed>,
+    oup::observable_unique_ptr<test_object_observer_from_this_constructor_unique>,
+    oup::observable_sealed_ptr<test_object_observer_from_this_constructor_sealed>,
+    oup::observable_unique_ptr<test_object_observer_from_this_constructor_multi_unique>,
+    oup::observable_sealed_ptr<test_object_observer_from_this_constructor_multi_sealed>,
+    oup::observable_unique_ptr<test_object_observer_owner>,
+    oup::observable_sealed_ptr<test_object_observer_owner>
+    >;
+// clang-format on
+
+#define CHECK_INSTANCES(TEST_OBJECTS, TEST_DELETER)                                                \
+    do {                                                                                           \
+        CHECK(instances == (TEST_OBJECTS));                                                        \
+        if constexpr (has_stateful_deleter<TestType>) {                                            \
+            CHECK(instances_deleter == (TEST_DELETER));                                            \
+        }                                                                                          \
+    } while (0)
+
+#define CHECK_INSTANCES_DERIVED(TEST_OBJECTS, TEST_DERIVED, TEST_DELETER)                          \
+    do {                                                                                           \
+        CHECK(instances == (TEST_OBJECTS));                                                        \
+        CHECK(instances_derived == (TEST_DERIVED));                                                \
+        if constexpr (has_stateful_deleter<TestType>) {                                            \
+            CHECK(instances_deleter == (TEST_DELETER));                                            \
+        }                                                                                          \
+    } while (0)
+
+#define CHECK_NO_LEAKS                                                                             \
+    do {                                                                                           \
+        CHECK_INSTANCES_DERIVED(0, 0, 0);                                                          \
+        CHECK(mem_track.allocated() == 0u);                                                        \
+        CHECK(mem_track.double_delete() == 0u);                                                    \
+    } while (0)
+
+#if defined(NDEBUG)
+// When not in debug (hence, assuming optimisations are turned on),
+// some compilers manage to optimise-out some heap allocations, so use a looser
+// check.
+#    define CHECK_MAX_ALLOC(MAX_ALLOC) CHECK(mem_track.allocated() <= MAX_ALLOC)
+#else
+// In debug, allocations must be exactly as expected.
+#    define CHECK_MAX_ALLOC(MAX_ALLOC) CHECK(mem_track.allocated() == MAX_ALLOC)
+#endif
+
+// clang-format off
+#if defined(__clang__)
+#    define SNITCH_WARNING_DISABLE_SELF_ASSIGN _Pragma("clang diagnostic ignored \"-Wself-assign-overloaded\"")
+#elif defined(__GNUC__)
+#    define SNITCH_WARNING_DISABLE_SELF_ASSIGN do {} while (0)
+#elif defined(_MSC_VER)
+#    define SNITCH_WARNING_DISABLE_SELF_ASSIGN do {} while (0)
+#else
+#    define SNITCH_WARNING_DISABLE_SELF_ASSIGN do {} while (0)
+#endif
+// clang-format on

--- a/tests/tests_common.hpp
+++ b/tests/tests_common.hpp
@@ -630,6 +630,16 @@ using owner_types = snatch::type_list<
         CHECK(mem_track.double_delete() == 0u);                                                    \
     } while (0)
 
+#if defined(NDEBUG)
+// When not in debug (hence, assuming optimisations are turned on),
+// some compilers manage to optimise-out some heap allocations, so use a looser
+// check.
+#    define CHECK_MAX_ALLOC(MAX_ALLOC) CHECK(mem_track.allocated() <= MAX_ALLOC)
+#else
+// In debug, allocations must be exactly as expected.
+#    define CHECK_MAX_ALLOC(MAX_ALLOC) CHECK(mem_track.allocated() == MAX_ALLOC)
+#endif
+
 // clang-format off
 #if defined(__clang__)
 #    define SNATCH_WARNING_DISABLE_SELF_ASSIGN _Pragma("clang diagnostic ignored \"-Wself-assign-overloaded\"")

--- a/tests/tests_common.hpp
+++ b/tests/tests_common.hpp
@@ -1,4 +1,5 @@
 #include "oup/observable_unique_ptr.hpp"
+#include "testing.hpp"
 
 #include <exception>
 
@@ -576,7 +577,7 @@ auto make_const_observer_from_this(const get_object<T>* ptr) {
 }
 
 // clang-format off
-using owner_types = std::tuple<
+using owner_types = snatch::type_list<
     oup::observable_unique_ptr<test_object>,
     oup::observable_sealed_ptr<test_object>,
     oup::observable_unique_ptr<const test_object>,

--- a/tests/tests_common.hpp
+++ b/tests/tests_common.hpp
@@ -1,5 +1,4 @@
 #include "oup/observable_unique_ptr.hpp"
-#include "testing.hpp"
 
 #include <exception>
 
@@ -575,79 +574,3 @@ auto make_const_observer_from_this(const get_object<T>* ptr) {
         return ptr->observer_from_this();
     }
 }
-
-// clang-format off
-using owner_types = snatch::type_list<
-    oup::observable_unique_ptr<test_object>,
-    oup::observable_sealed_ptr<test_object>,
-    oup::observable_unique_ptr<const test_object>,
-    oup::observable_sealed_ptr<const test_object>,
-    oup::observable_unique_ptr<test_object_derived>,
-    oup::observable_sealed_ptr<test_object_derived>,
-    oup::observable_unique_ptr<test_object, test_deleter>,
-    oup::observable_unique_ptr<test_object_derived, test_deleter>,
-    oup::observable_unique_ptr<test_object_observer_from_this_unique>,
-    oup::observable_sealed_ptr<test_object_observer_from_this_sealed>,
-    oup::basic_observable_ptr<test_object_observer_from_this_non_virtual_unique, oup::default_delete, unique_non_virtual_policy>,
-    oup::basic_observable_ptr<test_object_observer_from_this_maybe_no_block_unique, oup::default_delete, unique_maybe_no_block_policy>,
-    oup::basic_observable_ptr<test_object_observer_from_this_virtual_sealed, oup::placement_delete, sealed_virtual_policy>,
-    oup::observable_unique_ptr<const test_object_observer_from_this_unique>,
-    oup::observable_sealed_ptr<const test_object_observer_from_this_sealed>,
-    oup::observable_unique_ptr<test_object_observer_from_this_derived_unique>,
-    oup::observable_sealed_ptr<test_object_observer_from_this_derived_sealed>,
-    oup::observable_unique_ptr<test_object_observer_from_this_multi_unique>,
-    oup::observable_sealed_ptr<test_object_observer_from_this_multi_sealed>,
-    oup::observable_unique_ptr<test_object_observer_from_this_constructor_unique>,
-    oup::observable_sealed_ptr<test_object_observer_from_this_constructor_sealed>,
-    oup::observable_unique_ptr<test_object_observer_from_this_constructor_multi_unique>,
-    oup::observable_sealed_ptr<test_object_observer_from_this_constructor_multi_sealed>,
-    oup::observable_unique_ptr<test_object_observer_owner>,
-    oup::observable_sealed_ptr<test_object_observer_owner>
-    >;
-// clang-format on
-
-#define CHECK_INSTANCES(TEST_OBJECTS, TEST_DELETER)                                                \
-    do {                                                                                           \
-        CHECK(instances == (TEST_OBJECTS));                                                        \
-        if constexpr (has_stateful_deleter<TestType>) {                                            \
-            CHECK(instances_deleter == (TEST_DELETER));                                            \
-        }                                                                                          \
-    } while (0)
-
-#define CHECK_INSTANCES_DERIVED(TEST_OBJECTS, TEST_DERIVED, TEST_DELETER)                          \
-    do {                                                                                           \
-        CHECK(instances == (TEST_OBJECTS));                                                        \
-        CHECK(instances_derived == (TEST_DERIVED));                                                \
-        if constexpr (has_stateful_deleter<TestType>) {                                            \
-            CHECK(instances_deleter == (TEST_DELETER));                                            \
-        }                                                                                          \
-    } while (0)
-
-#define CHECK_NO_LEAKS                                                                             \
-    do {                                                                                           \
-        CHECK_INSTANCES_DERIVED(0, 0, 0);                                                          \
-        CHECK(mem_track.allocated() == 0u);                                                        \
-        CHECK(mem_track.double_delete() == 0u);                                                    \
-    } while (0)
-
-#if defined(NDEBUG)
-// When not in debug (hence, assuming optimisations are turned on),
-// some compilers manage to optimise-out some heap allocations, so use a looser
-// check.
-#    define CHECK_MAX_ALLOC(MAX_ALLOC) CHECK(mem_track.allocated() <= MAX_ALLOC)
-#else
-// In debug, allocations must be exactly as expected.
-#    define CHECK_MAX_ALLOC(MAX_ALLOC) CHECK(mem_track.allocated() == MAX_ALLOC)
-#endif
-
-// clang-format off
-#if defined(__clang__)
-#    define SNATCH_WARNING_DISABLE_SELF_ASSIGN _Pragma("clang diagnostic ignored \"-Wself-assign-overloaded\"")
-#elif defined(__GNUC__)
-#    define SNATCH_WARNING_DISABLE_SELF_ASSIGN do {} while (0)
-#elif defined(_MSC_VER)
-#    define SNATCH_WARNING_DISABLE_SELF_ASSIGN do {} while (0)
-#else
-#    define SNATCH_WARNING_DISABLE_SELF_ASSIGN do {} while (0)
-#endif
-// clang-format on


### PR DESCRIPTION
This PR does the following:
 - Update third-party libraries for testing and CI.
 - Update tests to use `volatile` on memory allocation counters, to prevent them being optimised.
 - Update tests to use looser checks on memory allocations, to allow heap allocations to be optimised-out in release builds.